### PR TITLE
Implement Phase 2: File Parsers and CLI Validate Command

### DIFF
--- a/fabricks-common/src/error.rs
+++ b/fabricks-common/src/error.rs
@@ -15,7 +15,9 @@ pub enum ValidationError {
     },
 
     /// The name format is invalid.
-    #[error("invalid name '{name}': must match pattern [a-z0-9-]+ (lowercase letters, numbers, and hyphens only)")]
+    #[error(
+        "invalid name '{name}': must match pattern [a-z0-9-]+ (lowercase letters, numbers, and hyphens only)"
+    )]
     InvalidName {
         /// The invalid name.
         name: String,

--- a/fabricks-common/src/lib.rs
+++ b/fabricks-common/src/lib.rs
@@ -6,13 +6,13 @@
 //!
 //! - [`models`] - Data structures for [`Fabrickfile`](models::Fabrickfile) and [`MortarFile`](models::MortarFile)
 //! - [`error`] - Error types for validation and parsing
+//! - [`parser`] - File parsing functions for configuration files
 //! - [`validation`] - Validation logic and traits
 //!
 //! # Example
 //!
 //! ```
-//! use fabricks_common::models::Fabrickfile;
-//! use fabricks_common::validation::Validate;
+//! use fabricks_common::parser::parse_fabrickfile_str;
 //!
 //! let toml = r#"
 //!     fabrick_version = "1.0"
@@ -25,15 +25,20 @@
 //!     listen = [8080]
 //! "#;
 //!
-//! let fabrickfile: Fabrickfile = toml::from_str(toml).unwrap();
-//! fabrickfile.validate().expect("validation failed");
+//! let fabrickfile = parse_fabrickfile_str(toml)?;
+//! assert_eq!(fabrickfile.info.name, "my-service");
+//! # Ok::<(), fabricks_common::ParseError>(())
 //! ```
 
 pub mod error;
 pub mod models;
+pub mod parser;
 pub mod validation;
 
 // Re-export commonly used types at crate root for convenience.
 pub use error::{ParseError, ValidationError};
 pub use models::{Capabilities, Fabrickfile, MortarFile};
+pub use parser::{
+    parse_fabrickfile, parse_fabrickfile_str, parse_mortar_file, parse_mortar_file_str,
+};
 pub use validation::Validate;

--- a/fabricks-common/src/models/common.rs
+++ b/fabricks-common/src/models/common.rs
@@ -51,9 +51,11 @@ impl FromStr for Duration {
             .find(|c: char| !c.is_ascii_digit())
             .map_or((s, ""), |i| s.split_at(i));
 
-        let num: u64 = num_str.parse().map_err(|_| ValidationError::InvalidDuration {
-            value: s.to_string(),
-        })?;
+        let num: u64 = num_str
+            .parse()
+            .map_err(|_| ValidationError::InvalidDuration {
+                value: s.to_string(),
+            })?;
 
         let multiplier = match unit {
             "s" | "sec" | "second" | "seconds" | "" => 1,
@@ -63,7 +65,7 @@ impl FromStr for Duration {
             _ => {
                 return Err(ValidationError::InvalidDuration {
                     value: s.to_string(),
-                })
+                });
             }
         };
 
@@ -159,9 +161,11 @@ impl FromStr for ByteSize {
             .find(|c: char| !c.is_ascii_digit())
             .map_or((s, ""), |i| s.split_at(i));
 
-        let num: u64 = num_str.parse().map_err(|_| ValidationError::InvalidByteSize {
-            value: s.to_string(),
-        })?;
+        let num: u64 = num_str
+            .parse()
+            .map_err(|_| ValidationError::InvalidByteSize {
+                value: s.to_string(),
+            })?;
 
         let multiplier: u64 = match unit {
             "" | "B" => 1,
@@ -176,13 +180,15 @@ impl FromStr for ByteSize {
             _ => {
                 return Err(ValidationError::InvalidByteSize {
                     value: s.to_string(),
-                })
+                });
             }
         };
 
-        let bytes = num.checked_mul(multiplier).ok_or_else(|| ValidationError::InvalidByteSize {
-            value: s.to_string(),
-        })?;
+        let bytes =
+            num.checked_mul(multiplier)
+                .ok_or_else(|| ValidationError::InvalidByteSize {
+                    value: s.to_string(),
+                })?;
 
         Ok(Self { bytes })
     }
@@ -332,9 +338,15 @@ mod tests {
         const MI: u64 = 1024 * 1024;
         const GI: u64 = 1024 * 1024 * 1024;
 
-        assert_eq!(ByteSize::from_str("256Mi").map(|b| b.as_bytes()), Ok(256 * MI));
+        assert_eq!(
+            ByteSize::from_str("256Mi").map(|b| b.as_bytes()),
+            Ok(256 * MI)
+        );
         assert_eq!(ByteSize::from_str("1Gi").map(|b| b.as_bytes()), Ok(GI));
-        assert_eq!(ByteSize::from_str("512Ki").map(|b| b.as_bytes()), Ok(512 * 1024));
+        assert_eq!(
+            ByteSize::from_str("512Ki").map(|b| b.as_bytes()),
+            Ok(512 * 1024)
+        );
         assert!(ByteSize::from_str("invalid").is_err());
     }
 

--- a/fabricks-common/src/models/mortar.rs
+++ b/fabricks-common/src/models/mortar.rs
@@ -662,7 +662,12 @@ mod tests {
         assert_eq!(mortar.mortar_version, "1.0");
         assert_eq!(mortar.project.name, "my-app");
         assert!(mortar.service.contains_key("api"));
-        assert!(mortar.network.as_ref().is_some_and(|n| n.contains_key("default")));
+        assert!(
+            mortar
+                .network
+                .as_ref()
+                .is_some_and(|n| n.contains_key("default"))
+        );
         Ok(())
     }
 
@@ -695,7 +700,12 @@ mod tests {
         let postgres = mortar.service.get("postgres");
         assert!(postgres.is_some());
         let postgres = postgres.unwrap_or_else(|| unreachable!());
-        assert!(postgres.volumes.as_ref().is_some_and(|v| v.contains_key("postgres_data")));
+        assert!(
+            postgres
+                .volumes
+                .as_ref()
+                .is_some_and(|v| v.contains_key("postgres_data"))
+        );
 
         // Verify volume exists with expected properties
         let volume = mortar.volume.as_ref().and_then(|v| v.get("postgres_data"));

--- a/fabricks-common/src/parser.rs
+++ b/fabricks-common/src/parser.rs
@@ -1,0 +1,281 @@
+//! File parsers for Fabrickfile and `MortarFile`.
+//!
+//! This module provides functions to parse configuration files from the filesystem.
+//! Each parser reads the file, deserializes the TOML content, and validates the result.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use fabricks_common::parser::{parse_fabrickfile, parse_mortar_file};
+//! use std::path::Path;
+//!
+//! // Parse a Fabrickfile
+//! let fabrickfile = parse_fabrickfile(Path::new("./Fabrickfile"))?;
+//!
+//! // Parse a mortar file
+//! let mortar = parse_mortar_file(Path::new("./fabricks-mortar.toml"))?;
+//! # Ok::<(), fabricks_common::ParseError>(())
+//! ```
+
+use std::fs;
+use std::path::Path;
+
+use crate::error::ParseError;
+use crate::models::{Fabrickfile, MortarFile};
+use crate::validation::Validate;
+
+/// The default filename for a Fabrickfile.
+pub const FABRICKFILE_NAME: &str = "Fabrickfile";
+
+/// The default filename for a mortar file.
+pub const MORTAR_FILE_NAME: &str = "fabricks-mortar.toml";
+
+/// Parse a Fabrickfile from a file path.
+///
+/// This function reads the file, parses the TOML content, and validates the result.
+/// The path can point either to the Fabrickfile directly or to a directory containing
+/// a file named "Fabrickfile".
+///
+/// # Arguments
+///
+/// * `path` - Path to the Fabrickfile or directory containing it
+///
+/// # Returns
+///
+/// The parsed and validated [`Fabrickfile`], or an error if parsing/validation fails.
+///
+/// # Errors
+///
+/// Returns [`ParseError::IoError`] if the file cannot be read.
+/// Returns [`ParseError::TomlError`] if the TOML is malformed.
+/// Returns [`ParseError::ValidationError`] if validation fails.
+///
+/// # Example
+///
+/// ```no_run
+/// use fabricks_common::parser::parse_fabrickfile;
+/// use std::path::Path;
+///
+/// let fabrickfile = parse_fabrickfile(Path::new("./Fabrickfile"))?;
+/// println!("Parsed fabrick: {}", fabrickfile.info.name);
+/// # Ok::<(), fabricks_common::ParseError>(())
+/// ```
+pub fn parse_fabrickfile(path: &Path) -> Result<Fabrickfile, ParseError> {
+    let file_path = resolve_fabrickfile_path(path);
+    let content = read_file(&file_path)?;
+    let fabrickfile: Fabrickfile = parse_toml(&content)?;
+    fabrickfile.validate()?;
+    Ok(fabrickfile)
+}
+
+/// Parse a Fabrickfile from a TOML string.
+///
+/// This function parses the TOML content and validates the result.
+/// Useful when you already have the file content in memory.
+///
+/// # Arguments
+///
+/// * `content` - TOML string content
+///
+/// # Returns
+///
+/// The parsed and validated [`Fabrickfile`], or an error if parsing/validation fails.
+///
+/// # Errors
+///
+/// Returns [`ParseError::TomlError`] if the TOML is malformed.
+/// Returns [`ParseError::ValidationError`] if validation fails.
+pub fn parse_fabrickfile_str(content: &str) -> Result<Fabrickfile, ParseError> {
+    let fabrickfile: Fabrickfile = parse_toml(content)?;
+    fabrickfile.validate()?;
+    Ok(fabrickfile)
+}
+
+/// Parse a mortar file from a file path.
+///
+/// This function reads the file, parses the TOML content, and validates the result.
+/// The path can point either to the mortar file directly or to a directory containing
+/// a file named "fabricks-mortar.toml".
+///
+/// # Arguments
+///
+/// * `path` - Path to the mortar file or directory containing it
+///
+/// # Returns
+///
+/// The parsed and validated [`MortarFile`], or an error if parsing/validation fails.
+///
+/// # Errors
+///
+/// Returns [`ParseError::IoError`] if the file cannot be read.
+/// Returns [`ParseError::TomlError`] if the TOML is malformed.
+/// Returns [`ParseError::ValidationError`] if validation fails.
+///
+/// # Example
+///
+/// ```no_run
+/// use fabricks_common::parser::parse_mortar_file;
+/// use std::path::Path;
+///
+/// let mortar = parse_mortar_file(Path::new("./fabricks-mortar.toml"))?;
+/// println!("Project: {}", mortar.project.name);
+/// # Ok::<(), fabricks_common::ParseError>(())
+/// ```
+pub fn parse_mortar_file(path: &Path) -> Result<MortarFile, ParseError> {
+    let file_path = resolve_mortar_path(path);
+    let content = read_file(&file_path)?;
+    let mortar: MortarFile = parse_toml(&content)?;
+    mortar.validate()?;
+    Ok(mortar)
+}
+
+/// Parse a mortar file from a TOML string.
+///
+/// This function parses the TOML content and validates the result.
+/// Useful when you already have the file content in memory.
+///
+/// # Arguments
+///
+/// * `content` - TOML string content
+///
+/// # Returns
+///
+/// The parsed and validated [`MortarFile`], or an error if parsing/validation fails.
+///
+/// # Errors
+///
+/// Returns [`ParseError::TomlError`] if the TOML is malformed.
+/// Returns [`ParseError::ValidationError`] if validation fails.
+pub fn parse_mortar_file_str(content: &str) -> Result<MortarFile, ParseError> {
+    let mortar: MortarFile = parse_toml(content)?;
+    mortar.validate()?;
+    Ok(mortar)
+}
+
+/// Resolve the path to a Fabrickfile.
+///
+/// If the path is a directory, appends the default Fabrickfile name.
+fn resolve_fabrickfile_path(path: &Path) -> std::path::PathBuf {
+    if path.is_dir() {
+        path.join(FABRICKFILE_NAME)
+    } else {
+        path.to_path_buf()
+    }
+}
+
+/// Resolve the path to a mortar file.
+///
+/// If the path is a directory, appends the default mortar file name.
+fn resolve_mortar_path(path: &Path) -> std::path::PathBuf {
+    if path.is_dir() {
+        path.join(MORTAR_FILE_NAME)
+    } else {
+        path.to_path_buf()
+    }
+}
+
+/// Read a file's content as a string.
+fn read_file(path: &std::path::PathBuf) -> Result<String, ParseError> {
+    fs::read_to_string(path).map_err(|source| ParseError::IoError {
+        path: path.display().to_string(),
+        source,
+    })
+}
+
+/// Parse TOML content into a type.
+fn parse_toml<T>(content: &str) -> Result<T, ParseError>
+where
+    T: serde::de::DeserializeOwned,
+{
+    toml::from_str(content).map_err(ParseError::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_fabrickfile_str_valid() {
+        let toml = r#"
+            fabrick_version = "1.0"
+
+            [info]
+            name = "my-service"
+            version = "1.0.0"
+
+            [capabilities.network]
+            listen = [8080]
+        "#;
+
+        let result = parse_fabrickfile_str(toml);
+        assert!(result.is_ok());
+        let fabrickfile = result.unwrap_or_else(|e| panic!("unexpected error: {e}"));
+        assert_eq!(fabrickfile.info.name, "my-service");
+        assert_eq!(fabrickfile.info.version, "1.0.0");
+    }
+
+    #[test]
+    fn test_parse_fabrickfile_str_invalid_toml() {
+        let toml = "this is not valid toml {{{";
+        let result = parse_fabrickfile_str(toml);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_fabrickfile_str_validation_error() {
+        let toml = r#"
+            fabrick_version = "1.0"
+
+            [info]
+            name = "Invalid_Name"
+            version = "1.0.0"
+        "#;
+
+        let result = parse_fabrickfile_str(toml);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_mortar_file_str_valid() {
+        let toml = r#"
+            mortar_version = "1.0"
+
+            [project]
+            name = "my-project"
+
+            [network.internal]
+            internal = true
+
+            [service.api]
+            build = "./api"
+            networks = ["internal"]
+        "#;
+
+        let result = parse_mortar_file_str(toml);
+        assert!(result.is_ok());
+        let mortar = result.unwrap_or_else(|e| panic!("unexpected error: {e}"));
+        assert_eq!(mortar.project.name, "my-project");
+        assert!(mortar.service.contains_key("api"));
+    }
+
+    #[test]
+    fn test_parse_mortar_file_str_invalid_toml() {
+        let toml = "this is not valid toml {{{";
+        let result = parse_mortar_file_str(toml);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_fabrickfile_path_file() {
+        let path = Path::new("/some/path/Fabrickfile");
+        let resolved = resolve_fabrickfile_path(path);
+        assert_eq!(resolved, path);
+    }
+
+    #[test]
+    fn test_resolve_mortar_path_file() {
+        let path = Path::new("/some/path/fabricks-mortar.toml");
+        let resolved = resolve_mortar_path(path);
+        assert_eq!(resolved, path);
+    }
+}

--- a/fabricks-common/src/validation.rs
+++ b/fabricks-common/src/validation.rs
@@ -3,8 +3,8 @@
 use std::collections::HashSet;
 
 use crate::error::ValidationError;
-use crate::models::fabrickfile::{Fabrickfile, From, FABRICK_VERSION};
-use crate::models::mortar::{MortarFile, Service, MORTAR_VERSION};
+use crate::models::fabrickfile::{FABRICK_VERSION, Fabrickfile, From};
+use crate::models::mortar::{MORTAR_VERSION, MortarFile, Service};
 
 /// Trait for types that can be validated.
 pub trait Validate {
@@ -71,10 +71,12 @@ fn validate_host_port(value: &str) -> Result<(), ValidationError> {
     }
 
     let port_str = parts[0];
-    let port: u32 = port_str.parse().map_err(|_| ValidationError::InvalidHostPort {
-        value: value.to_string(),
-        reason: format!("invalid port number: {port_str}"),
-    })?;
+    let port: u32 = port_str
+        .parse()
+        .map_err(|_| ValidationError::InvalidHostPort {
+            value: value.to_string(),
+            reason: format!("invalid port number: {port_str}"),
+        })?;
 
     validate_port(port).map_err(|_| ValidationError::InvalidHostPort {
         value: value.to_string(),
@@ -167,7 +169,11 @@ fn validate_url(url: &str) -> Result<(), ValidationError> {
 }
 
 fn validate_from(from: &From) -> Result<(), ValidationError> {
-    let specified = [from.source.is_some(), from.image.is_some(), from.path.is_some()];
+    let specified = [
+        from.source.is_some(),
+        from.image.is_some(),
+        from.path.is_some(),
+    ];
     let count = specified.iter().filter(|&&x| x).count();
 
     if count > 1 {
@@ -223,7 +229,9 @@ impl Validate for MortarFile {
 
         // Validate each service
         for (name, service) in &self.service {
-            if let Err(e) = validate_service(name, service, &network_names, &volume_names, &service_names) {
+            if let Err(e) =
+                validate_service(name, service, &network_names, &volume_names, &service_names)
+            {
                 match e {
                     ValidationError::Multiple(mut sub_errors) => errors.append(&mut sub_errors),
                     e => errors.push(e),

--- a/fabricks-common/tests/integration_tests.rs
+++ b/fabricks-common/tests/integration_tests.rs
@@ -1,0 +1,255 @@
+//! Integration tests for parsing configuration files.
+//!
+//! These tests verify that the parser can correctly handle real-world configuration files.
+
+use std::path::Path;
+
+use fabricks_common::parser::{parse_fabrickfile, parse_fabrickfile_str, parse_mortar_file_str};
+
+/// Test parsing the hello-world example Fabrickfile.
+#[test]
+fn test_parse_hello_world_fabrickfile() {
+    let path = Path::new("../examples/hello-world/Fabrickfile");
+    let result = parse_fabrickfile(path);
+
+    assert!(
+        result.is_ok(),
+        "Failed to parse hello-world Fabrickfile: {result:?}"
+    );
+    let fabrickfile = result.unwrap_or_else(|e| panic!("unexpected error: {e}"));
+
+    assert_eq!(fabrickfile.fabrick_version, "1.0");
+    assert_eq!(fabrickfile.info.name, "hello-world");
+    assert_eq!(fabrickfile.info.version, "1.0.0");
+    assert!(fabrickfile.capabilities.can_listen(8080));
+}
+
+/// Test parsing a more complex Fabrickfile with all sections.
+#[test]
+fn test_parse_complex_fabrickfile() {
+    let toml = r#"
+fabrick_version = "1.0"
+
+[info]
+name = "payment-api"
+version = "2.1.0"
+description = "Payment processing service"
+authors = ["Team <team@example.com>"]
+license = "MIT"
+homepage = "https://example.com"
+repository = "https://github.com/example/payment"
+documentation = "https://docs.example.com"
+keywords = ["payment", "api"]
+
+[from]
+source = "rust"
+
+[source]
+path = "./src"
+include = ["**/*.rs", "Cargo.toml"]
+exclude = ["**/tests/**"]
+
+[build]
+command = "cargo build --target wasm32-wasi --release"
+output = "target/wasm32-wasi/release/payment.wasm"
+workdir = "."
+watch = ["src/**/*.rs", "Cargo.toml"]
+
+[exports]
+interface = { "payment:api" = { version = "1.0.0" } }
+
+[capabilities]
+env = ["API_KEY", "LOG_LEVEL"]
+
+[capabilities.network]
+listen = [8080, 8443]
+connect = ["stripe.com:443", "postgres:5432"]
+
+[capabilities.filesystem]
+read = ["/config"]
+write = ["/tmp"]
+
+[capabilities.wasm]
+threads = true
+max_memory = "512Mi"
+
+[config]
+port = 8080
+timeout = 30
+log_level = "info"
+
+[config.resources]
+memory = "256Mi"
+cpu = 0.5
+
+[health_check.http]
+path = "/health"
+port = 8080
+interval = "30s"
+timeout = "5s"
+retries = 3
+success_threshold = 1
+
+[security]
+user = "app"
+deny_by_default = true
+read_only_root = true
+drop_capabilities = ["NET_RAW"]
+
+[validate]
+check_exports = true
+check_imports = true
+    "#;
+
+    let result = parse_fabrickfile_str(toml);
+    assert!(
+        result.is_ok(),
+        "Failed to parse complex Fabrickfile: {result:?}"
+    );
+
+    let fabrickfile = result.unwrap_or_else(|e| panic!("unexpected error: {e}"));
+    assert_eq!(fabrickfile.info.name, "payment-api");
+    assert_eq!(fabrickfile.info.version, "2.1.0");
+    assert!(fabrickfile.capabilities.can_listen(8080));
+    assert!(fabrickfile.capabilities.can_listen(8443));
+    assert!(fabrickfile.capabilities.can_connect("stripe.com:443"));
+    assert!(fabrickfile.capabilities.can_access_env("API_KEY"));
+}
+
+/// Test parsing a mortar file with multiple services.
+#[test]
+fn test_parse_mortar_with_services() {
+    let toml = r#"
+mortar_version = "1.0"
+
+[project]
+name = "my-app"
+version = "1.0.0"
+description = "Test application"
+
+[network.internal]
+internal = true
+description = "Internal network"
+
+[network.public]
+ingress = "0.0.0.0/0"
+egress = ["internal"]
+
+[service.api]
+build = "./api"
+networks = ["public", "internal"]
+ports = ["8080:8080"]
+depends_on = ["db"]
+
+[service.api.resources]
+memory = "256Mi"
+cpu = 0.5
+
+[service.api.health_check.http]
+path = "/health"
+interval = "30s"
+
+[service.db]
+image = "wasm://postgres:latest"
+networks = ["internal"]
+
+[service.db.volumes]
+data = "/var/lib/postgresql/data"
+
+[service.db.resources]
+memory = "512Mi"
+cpu = 1.0
+
+[volume.data]
+size = "10Gi"
+    "#;
+
+    let result = parse_mortar_file_str(toml);
+    assert!(result.is_ok(), "Failed to parse mortar file: {result:?}");
+
+    let mortar = result.unwrap_or_else(|e| panic!("unexpected error: {e}"));
+    assert_eq!(mortar.project.name, "my-app");
+    assert_eq!(mortar.service.len(), 2);
+    assert!(mortar.service.contains_key("api"));
+    assert!(mortar.service.contains_key("db"));
+
+    let network = mortar.network.as_ref().map(|n| n.len()).unwrap_or(0);
+    assert_eq!(network, 2);
+}
+
+/// Test that validation catches missing required fields.
+#[test]
+fn test_validation_missing_service_source() {
+    let toml = r#"
+mortar_version = "1.0"
+
+[project]
+name = "test-app"
+
+[network.internal]
+internal = true
+
+[service.api]
+networks = ["internal"]
+    "#;
+
+    let result = parse_mortar_file_str(toml);
+    assert!(
+        result.is_err(),
+        "Should fail validation - service missing build/image"
+    );
+}
+
+/// Test that validation catches invalid service references.
+#[test]
+fn test_validation_invalid_network_reference() {
+    let toml = r#"
+mortar_version = "1.0"
+
+[project]
+name = "test-app"
+
+[network.internal]
+internal = true
+
+[service.api]
+build = "./api"
+networks = ["nonexistent"]
+    "#;
+
+    let result = parse_mortar_file_str(toml);
+    assert!(
+        result.is_err(),
+        "Should fail validation - network 'nonexistent' not found"
+    );
+}
+
+/// Test that validation catches circular dependencies.
+#[test]
+fn test_validation_circular_dependency() {
+    let toml = r#"
+mortar_version = "1.0"
+
+[project]
+name = "test-app"
+
+[network.internal]
+internal = true
+
+[service.a]
+build = "./a"
+networks = ["internal"]
+depends_on = ["b"]
+
+[service.b]
+build = "./b"
+networks = ["internal"]
+depends_on = ["a"]
+    "#;
+
+    let result = parse_mortar_file_str(toml);
+    assert!(
+        result.is_err(),
+        "Should fail validation - circular dependency detected"
+    );
+}

--- a/fabricks/src/cli.rs
+++ b/fabricks/src/cli.rs
@@ -1,0 +1,75 @@
+//! CLI argument definitions using clap.
+
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand, ValueEnum};
+
+/// Fabricks - Declarative WASM Orchestration Platform.
+///
+/// Build, deploy, and manage WebAssembly microservices with a familiar,
+/// container-like workflow.
+#[derive(Parser, Debug)]
+#[command(name = "fabricks")]
+#[command(version, about, long_about = None)]
+#[command(propagate_version = true)]
+pub struct Cli {
+    /// Enable verbose output.
+    #[arg(short, long, global = true)]
+    pub verbose: bool,
+
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+/// Available CLI commands.
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Validate configuration files.
+    ///
+    /// Checks Fabrickfile or fabricks-mortar.toml for syntax errors
+    /// and validates all fields according to the specification.
+    Validate(ValidateArgs),
+
+    /// Show version information.
+    Version,
+}
+
+/// Arguments for the validate command.
+#[derive(Parser, Debug)]
+pub struct ValidateArgs {
+    /// Path to the file or directory to validate.
+    ///
+    /// If a directory is provided, looks for Fabrickfile or
+    /// fabricks-mortar.toml based on the --type flag.
+    #[arg(default_value = ".")]
+    pub path: PathBuf,
+
+    /// Type of file to validate.
+    ///
+    /// If not specified, attempts to auto-detect based on filename.
+    #[arg(short = 't', long = "type", value_enum)]
+    pub file_type: Option<FileType>,
+
+    /// Output format for validation results.
+    #[arg(short, long, value_enum, default_value = "text")]
+    pub format: OutputFormat,
+}
+
+/// Type of configuration file.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum FileType {
+    /// Fabrickfile (single service definition).
+    Fabrickfile,
+    /// fabricks-mortar.toml (multi-service composition).
+    Mortar,
+}
+
+/// Output format for command results.
+#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+pub enum OutputFormat {
+    /// Human-readable text output.
+    #[default]
+    Text,
+    /// JSON output for programmatic consumption.
+    Json,
+}

--- a/fabricks/src/commands/mod.rs
+++ b/fabricks/src/commands/mod.rs
@@ -1,0 +1,4 @@
+//! CLI command implementations.
+
+pub mod validate;
+pub mod version;

--- a/fabricks/src/commands/validate.rs
+++ b/fabricks/src/commands/validate.rs
@@ -1,0 +1,129 @@
+//! Validate command implementation.
+//!
+//! Validates Fabrickfile or fabricks-mortar.toml configuration files.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use fabricks_common::parser::{FABRICKFILE_NAME, MORTAR_FILE_NAME};
+use fabricks_common::{parse_fabrickfile, parse_mortar_file};
+
+use crate::cli::{FileType, OutputFormat, ValidateArgs};
+use crate::output::writeln_stderr;
+
+/// Run the validate command.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The file cannot be read
+/// - The TOML is malformed
+/// - Validation fails
+pub fn run(args: &ValidateArgs) -> Result<()> {
+    let path = &args.path;
+
+    // Determine file type
+    let file_type = args
+        .file_type
+        .or_else(|| detect_file_type(path))
+        .context("Could not determine file type. Use --type to specify.")?;
+
+    match file_type {
+        FileType::Fabrickfile => validate_fabrickfile(path, args.format),
+        FileType::Mortar => validate_mortar(path, args.format),
+    }
+}
+
+/// Detect file type based on path.
+fn detect_file_type(path: &Path) -> Option<FileType> {
+    if path.is_file() {
+        let filename = path.file_name()?.to_str()?;
+        if filename == FABRICKFILE_NAME || filename.ends_with(".fabrickfile") {
+            return Some(FileType::Fabrickfile);
+        }
+        if filename == MORTAR_FILE_NAME || filename.ends_with("-mortar.toml") {
+            return Some(FileType::Mortar);
+        }
+        None
+    } else if path.is_dir() {
+        // Check which file exists in the directory
+        let fabrickfile = path.join(FABRICKFILE_NAME);
+        let mortar = path.join(MORTAR_FILE_NAME);
+
+        if fabrickfile.exists() && mortar.exists() {
+            // Both exist, prefer mortar (project-level)
+            Some(FileType::Mortar)
+        } else if mortar.exists() {
+            Some(FileType::Mortar)
+        } else if fabrickfile.exists() {
+            Some(FileType::Fabrickfile)
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+/// Validate a Fabrickfile.
+fn validate_fabrickfile(path: &Path, format: OutputFormat) -> Result<()> {
+    let fabrickfile = parse_fabrickfile(path)?;
+
+    match format {
+        OutputFormat::Text => {
+            writeln_stderr(&format!(
+                "✓ Valid Fabrickfile: {} v{}",
+                fabrickfile.info.name, fabrickfile.info.version
+            ))?;
+        }
+        OutputFormat::Json => {
+            let output = serde_json::json!({
+                "valid": true,
+                "type": "fabrickfile",
+                "name": fabrickfile.info.name,
+                "version": fabrickfile.info.version,
+            });
+            writeln_stderr(&serde_json::to_string_pretty(&output)?)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate a mortar file.
+fn validate_mortar(path: &Path, format: OutputFormat) -> Result<()> {
+    let mortar = parse_mortar_file(path)?;
+
+    let service_count = mortar.service.len();
+    let network_count = mortar
+        .network
+        .as_ref()
+        .map_or(0, std::collections::HashMap::len);
+    let volume_count = mortar
+        .volume
+        .as_ref()
+        .map_or(0, std::collections::HashMap::len);
+
+    match format {
+        OutputFormat::Text => {
+            writeln_stderr(&format!("✓ Valid mortar file: {}", mortar.project.name))?;
+            writeln_stderr(&format!(
+                "  Services: {service_count}, Networks: {network_count}, Volumes: {volume_count}"
+            ))?;
+        }
+        OutputFormat::Json => {
+            let output = serde_json::json!({
+                "valid": true,
+                "type": "mortar",
+                "name": mortar.project.name,
+                "version": mortar.project.version,
+                "services": service_count,
+                "networks": network_count,
+                "volumes": volume_count,
+            });
+            writeln_stderr(&serde_json::to_string_pretty(&output)?)?;
+        }
+    }
+
+    Ok(())
+}

--- a/fabricks/src/commands/version.rs
+++ b/fabricks/src/commands/version.rs
@@ -1,0 +1,20 @@
+//! Version command implementation.
+
+use anyhow::Result;
+
+use crate::output::writeln_stderr;
+
+/// The current version of the fabricks CLI.
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Run the version command.
+///
+/// Displays version information about the fabricks CLI.
+///
+/// # Errors
+///
+/// Returns an error if writing to stderr fails.
+pub fn run() -> Result<()> {
+    writeln_stderr(&format!("fabricks {VERSION}"))?;
+    Ok(())
+}

--- a/fabricks/src/main.rs
+++ b/fabricks/src/main.rs
@@ -14,6 +14,47 @@
 //! - `fabricks logout` - Remove registry credentials
 //! - `fabricks version` - Show version information
 
-fn main() {
-    // CLI implementation will be added in Phase 5
+use std::process::ExitCode;
+
+use clap::Parser;
+
+mod cli;
+mod commands;
+mod output;
+
+use cli::{Cli, Commands};
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    // Initialize tracing if verbose mode is enabled
+    if cli.verbose {
+        init_tracing();
+    }
+
+    let result = match cli.command {
+        Commands::Validate(args) => commands::validate::run(&args),
+        Commands::Version => commands::version::run(),
+    };
+
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            // Ignore I/O errors when writing error messages
+            let _ = output::writeln_stderr(&format!("Error: {e}"));
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// Initialize tracing subscriber for verbose output.
+fn init_tracing() {
+    use tracing_subscriber::EnvFilter;
+
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_target(true)
+        .init();
 }

--- a/fabricks/src/output.rs
+++ b/fabricks/src/output.rs
@@ -1,0 +1,16 @@
+//! Output utilities for CLI commands.
+//!
+//! This module provides a consistent way to write output to stderr,
+//! avoiding the clippy `print_stderr` lint while maintaining testability.
+
+use std::io::{self, Write};
+
+/// Write a line to stderr.
+///
+/// # Errors
+///
+/// Returns an error if writing to stderr fails.
+pub fn writeln_stderr(message: &str) -> io::Result<()> {
+    let mut stderr = io::stderr();
+    writeln!(stderr, "{message}")
+}


### PR DESCRIPTION
## Summary

- Add parser module with file-based and string-based parsing functions
- Implement fabricks CLI with validate and version commands
- Add integration tests for parsing and validation

### Parser Module
- `parse_fabrickfile` / `parse_mortar_file` - Parse from file paths
- `parse_fabrickfile_str` / `parse_mortar_file_str` - Parse from strings
- Automatic directory resolution (looks for Fabrickfile or fabricks-mortar.toml)
- Full validation after parsing

### CLI Commands
- `fabricks validate [path] [--type fabrickfile|mortar] [--format text|json]`
- `fabricks version`
- Auto-detection of file type based on filename

### Integration Tests
- Tests against hello-world example
- Complex Fabrickfile with all sections
- Mortar file parsing with services, networks, volumes
- Validation error detection (circular deps, missing refs, missing build/image)

## Test plan

- [x] `cargo build --all` succeeds
- [x] `cargo test --all` passes (37 tests total)
- [x] `cargo clippy --all -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes