### PR TITLE
Implement Phase 3: OCI Registry Client

### DIFF
--- a/fabricks-oci/Cargo.toml
+++ b/fabricks-oci/Cargo.toml
@@ -21,14 +21,15 @@ path = "src/lib.rs"
 [dependencies]
 fabricks-common = { path = "../fabricks-common" }
 
+# OCI registry client
+oci-client = { version = "0.15", default-features = false, features = ["rustls-tls"] }
+
 tokio.workspace = true
-reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+toml.workspace = true
 thiserror.workspace = true
-anyhow.workspace = true
 url.workspace = true
-base64.workspace = true
 sha2.workspace = true
 hex.workspace = true
 bytes.workspace = true

--- a/fabricks-oci/src/client.rs
+++ b/fabricks-oci/src/client.rs
@@ -1,0 +1,350 @@
+//! OCI registry client for Fabricks modules.
+//!
+//! This module provides a high-level API for pushing and pulling Fabricks WASM
+//! modules to/from OCI-compliant registries.
+
+use std::collections::BTreeMap;
+
+use oci_client::client::{ClientConfig as OciClientConfig, ImageLayer};
+use oci_client::errors::OciErrorCode;
+use oci_client::manifest::{OciDescriptor, OciImageManifest, OCI_IMAGE_MEDIA_TYPE};
+use oci_client::secrets::RegistryAuth;
+use oci_client::{Client as OciClient, Reference, RegistryOperation};
+use tracing::{debug, info};
+
+use crate::digest::compute_digest;
+use crate::error::{OciError, Result};
+use crate::media_types;
+use crate::module::{FabricksModule, PulledModule};
+
+/// Configuration for the Fabricks OCI client.
+#[derive(Debug, Clone, Default)]
+pub struct ClientConfig {
+    /// Whether to accept invalid TLS certificates (for testing).
+    pub accept_invalid_certs: bool,
+}
+
+/// Client for pushing and pulling Fabricks modules to/from OCI registries.
+pub struct FabricksClient {
+    /// The underlying OCI client.
+    client: OciClient,
+}
+
+impl FabricksClient {
+    /// Create a new Fabricks OCI client with default configuration.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            client: OciClient::default(),
+        }
+    }
+
+    /// Create a new client with custom configuration.
+    #[must_use]
+    pub fn with_config(config: &ClientConfig) -> Self {
+        let oci_config = OciClientConfig {
+            accept_invalid_certificates: config.accept_invalid_certs,
+            ..Default::default()
+        };
+
+        Self {
+            client: OciClient::new(oci_config),
+        }
+    }
+
+    /// Push a Fabricks module to a registry.
+    ///
+    /// # Arguments
+    ///
+    /// * `reference` - The image reference (e.g., "ghcr.io/user/my-module:1.0.0")
+    /// * `module` - The Fabricks module to push
+    /// * `auth` - Registry authentication credentials
+    ///
+    /// # Returns
+    ///
+    /// The manifest digest of the pushed module.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the push fails.
+    pub async fn push(
+        &self,
+        reference: &Reference,
+        module: &FabricksModule,
+        auth: &RegistryAuth,
+    ) -> Result<String> {
+        info!(
+            "Pushing module {}:{} to {}",
+            module.name(),
+            module.version(),
+            reference
+        );
+
+        // Authenticate with the registry
+        self.client
+            .auth(reference, auth, RegistryOperation::Push)
+            .await?;
+
+        // Serialize config to TOML
+        let config_bytes = module
+            .config_bytes()
+            .map_err(|e| OciError::ConfigParseError {
+                reason: e.to_string(),
+            })?;
+
+        // Build layers
+        let layers = vec![ImageLayer {
+            data: module.wasm_bytes().to_vec(),
+            media_type: media_types::WASM_LAYER_MEDIA_TYPE.to_string(),
+            annotations: None,
+        }];
+
+        // Build annotations
+        let annotations = module.build_annotations();
+        let annotations_btree: BTreeMap<String, String> = annotations.into_iter().collect();
+
+        // Build manifest
+        let manifest = build_manifest(&config_bytes, &layers, annotations_btree);
+
+        // Push config blob
+        let config_digest = compute_digest(&config_bytes);
+        debug!("Pushing config blob: {config_digest}");
+        self.client
+            .push_blob(reference, &config_bytes, &config_digest)
+            .await?;
+
+        // Push layers
+        for layer in &layers {
+            let digest = compute_digest(&layer.data);
+            debug!("Pushing layer: {digest}");
+            self.client.push_blob(reference, &layer.data, &digest).await?;
+        }
+
+        // Push manifest
+        debug!("Pushing manifest");
+        let oci_manifest = oci_client::manifest::OciManifest::Image(manifest);
+        let manifest_url = self.client.push_manifest(reference, &oci_manifest).await?;
+
+        info!("Successfully pushed to {manifest_url}");
+        Ok(manifest_url)
+    }
+
+    /// Pull a Fabricks module from a registry.
+    ///
+    /// # Arguments
+    ///
+    /// * `reference` - The image reference (e.g., "ghcr.io/user/my-module:1.0.0")
+    /// * `auth` - Registry authentication credentials
+    ///
+    /// # Returns
+    ///
+    /// The pulled module with its manifest digest.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the pull fails or the module is invalid.
+    pub async fn pull(&self, reference: &Reference, auth: &RegistryAuth) -> Result<PulledModule> {
+        info!("Pulling module from {reference}");
+
+        // Authenticate with the registry
+        self.client
+            .auth(reference, auth, RegistryOperation::Pull)
+            .await?;
+
+        // Pull manifest
+        let (manifest, digest) = self.client.pull_manifest(reference, auth).await?;
+
+        let image_manifest = match manifest {
+            oci_client::manifest::OciManifest::Image(m) => m,
+            oci_client::manifest::OciManifest::ImageIndex(_) => {
+                return Err(OciError::UnsupportedMediaType {
+                    media_type: "manifest list".to_string(),
+                });
+            }
+        };
+
+        // Find WASM layer
+        let wasm_layer = image_manifest
+            .layers
+            .iter()
+            .find(|l| media_types::is_fabricks_module(&l.media_type))
+            .ok_or_else(|| OciError::InvalidModule {
+                reason: "no WASM layer found".to_string(),
+            })?;
+
+        // Pull WASM blob
+        debug!("Pulling WASM layer: {}", wasm_layer.digest);
+        let mut wasm_bytes = Vec::new();
+        self.client
+            .pull_blob(reference, wasm_layer, &mut wasm_bytes)
+            .await?;
+
+        // Pull config blob
+        debug!("Pulling config: {}", image_manifest.config.digest);
+        let mut config_bytes = Vec::new();
+        self.client
+            .pull_blob(reference, &image_manifest.config, &mut config_bytes)
+            .await?;
+
+        // Parse config
+        let config = parse_config(&config_bytes, &image_manifest)?;
+
+        let module = FabricksModule::new(config, wasm_bytes);
+
+        Ok(PulledModule {
+            module,
+            digest,
+        })
+    }
+
+    /// Check if a module exists in the registry.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the check fails (other than 404).
+    pub async fn exists(&self, reference: &Reference, auth: &RegistryAuth) -> Result<bool> {
+        // Authenticate first
+        self.client
+            .auth(reference, auth, RegistryOperation::Pull)
+            .await?;
+
+        match self.client.fetch_manifest_digest(reference, auth).await {
+            Ok(_) => Ok(true),
+            Err(oci_client::errors::OciDistributionError::RegistryError { envelope, .. })
+                if envelope.errors.iter().any(|e| {
+                    e.code == OciErrorCode::ManifestUnknown
+                        || e.code == OciErrorCode::NameUnknown
+                }) =>
+            {
+                Ok(false)
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// List tags for an image.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn list_tags(
+        &self,
+        reference: &Reference,
+        auth: &RegistryAuth,
+    ) -> Result<Vec<String>> {
+        // Authenticate first
+        self.client
+            .auth(reference, auth, RegistryOperation::Pull)
+            .await?;
+
+        let response = self.client.list_tags(reference, auth, None, None).await?;
+        Ok(response.tags)
+    }
+}
+
+impl Default for FabricksClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Build an OCI image manifest for a Fabricks module.
+fn build_manifest(
+    config_bytes: &[u8],
+    layers: &[ImageLayer],
+    annotations: BTreeMap<String, String>,
+) -> OciImageManifest {
+    let config_descriptor = OciDescriptor {
+        media_type: media_types::CONFIG_MEDIA_TYPE.to_string(),
+        digest: compute_digest(config_bytes),
+        size: i64::try_from(config_bytes.len()).unwrap_or(i64::MAX),
+        urls: None,
+        annotations: None,
+    };
+
+    let layer_descriptors: Vec<OciDescriptor> = layers
+        .iter()
+        .map(|l| OciDescriptor {
+            media_type: l.media_type.clone(),
+            digest: compute_digest(&l.data),
+            size: i64::try_from(l.data.len()).unwrap_or(i64::MAX),
+            urls: None,
+            annotations: l.annotations.clone(),
+        })
+        .collect();
+
+    OciImageManifest {
+        schema_version: 2,
+        media_type: Some(OCI_IMAGE_MEDIA_TYPE.to_string()),
+        artifact_type: Some(media_types::ARTIFACT_TYPE.to_string()),
+        config: config_descriptor,
+        layers: layer_descriptors,
+        subject: None,
+        annotations: Some(annotations),
+    }
+}
+
+/// Parse config from pulled bytes, falling back to annotations if needed.
+fn parse_config(
+    config_bytes: &[u8],
+    manifest: &OciImageManifest,
+) -> Result<fabricks_common::Fabrickfile> {
+    // First try to parse as TOML
+    if let Ok(config_str) = std::str::from_utf8(config_bytes)
+        && let Ok(config) = toml::from_str(config_str)
+    {
+        return Ok(config);
+    }
+
+    // Fall back to building minimal config from annotations
+    let annotations = manifest.annotations.as_ref().ok_or_else(|| OciError::InvalidModule {
+        reason: "no config or annotations found".to_string(),
+    })?;
+
+    let name = annotations
+        .get(media_types::ANNOTATION_NAME)
+        .ok_or_else(|| OciError::InvalidModule {
+            reason: "missing name annotation".to_string(),
+        })?
+        .clone();
+
+    let version = annotations
+        .get(media_types::ANNOTATION_VERSION)
+        .ok_or_else(|| OciError::InvalidModule {
+            reason: "missing version annotation".to_string(),
+        })?
+        .clone();
+
+    Ok(fabricks_common::Fabrickfile {
+        fabrick_version: annotations
+            .get(media_types::ANNOTATION_FABRICK_VERSION)
+            .cloned()
+            .unwrap_or_else(|| "1.0".to_string()),
+        info: fabricks_common::models::fabrickfile::Info {
+            name,
+            version,
+            description: annotations.get(media_types::ANNOTATION_DESCRIPTION).cloned(),
+            authors: annotations
+                .get(media_types::ANNOTATION_AUTHORS)
+                .map(|a| a.split(", ").map(String::from).collect()),
+            license: annotations.get(media_types::ANNOTATION_LICENSE).cloned(),
+            homepage: None,
+            repository: annotations.get(media_types::ANNOTATION_SOURCE).cloned(),
+            documentation: None,
+            keywords: None,
+        },
+        from: None,
+        source: None,
+        runtime: None,
+        build: None,
+        exports: None,
+        imports: None,
+        capabilities: fabricks_common::Capabilities::default(),
+        files: None,
+        config: None,
+        health_check: None,
+        security: None,
+        labels: None,
+        validate: None,
+    })
+}

--- a/fabricks-oci/src/digest.rs
+++ b/fabricks-oci/src/digest.rs
@@ -1,0 +1,166 @@
+//! Content-addressable digest computation.
+//!
+//! OCI uses SHA256 digests in the format `sha256:<hex>` to identify blobs.
+
+use sha2::{Digest as Sha2Digest, Sha256};
+
+/// Compute the SHA256 digest of content in OCI format.
+///
+/// Returns a string in the format `sha256:<64-char-hex>`.
+///
+/// # Example
+///
+/// ```
+/// use fabricks_oci::digest::compute_digest;
+///
+/// let data = b"hello world";
+/// let digest = compute_digest(data);
+/// assert!(digest.starts_with("sha256:"));
+/// assert_eq!(digest.len(), 7 + 64); // "sha256:" + 64 hex chars
+/// ```
+#[must_use]
+pub fn compute_digest(content: &[u8]) -> String {
+    let hash = Sha256::digest(content);
+    format!("sha256:{}", hex::encode(hash))
+}
+
+/// Verify that content matches an expected digest.
+///
+/// # Errors
+///
+/// Returns an error if the computed digest doesn't match the expected digest.
+pub fn verify_digest(content: &[u8], expected: &str) -> Result<(), DigestError> {
+    let actual = compute_digest(content);
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(DigestError::Mismatch {
+            expected: expected.to_string(),
+            actual,
+        })
+    }
+}
+
+/// Parse a digest string into algorithm and hash parts.
+///
+/// # Errors
+///
+/// Returns an error if the digest format is invalid.
+pub fn parse_digest(digest: &str) -> Result<(&str, &str), DigestError> {
+    let parts: Vec<&str> = digest.splitn(2, ':').collect();
+    if parts.len() != 2 {
+        return Err(DigestError::InvalidFormat {
+            digest: digest.to_string(),
+        });
+    }
+
+    let algorithm = parts[0];
+    let hash = parts[1];
+
+    // Validate algorithm
+    if algorithm != "sha256" && algorithm != "sha512" {
+        return Err(DigestError::UnsupportedAlgorithm {
+            algorithm: algorithm.to_string(),
+        });
+    }
+
+    // Validate hash length
+    let expected_len = match algorithm {
+        "sha256" => 64,
+        "sha512" => 128,
+        _ => unreachable!(),
+    };
+
+    if hash.len() != expected_len {
+        return Err(DigestError::InvalidFormat {
+            digest: digest.to_string(),
+        });
+    }
+
+    // Validate hex characters
+    if !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(DigestError::InvalidFormat {
+            digest: digest.to_string(),
+        });
+    }
+
+    Ok((algorithm, hash))
+}
+
+/// Errors related to digest operations.
+#[derive(Debug, thiserror::Error)]
+pub enum DigestError {
+    /// Digest format is invalid.
+    #[error("invalid digest format: {digest}")]
+    InvalidFormat {
+        /// The invalid digest string.
+        digest: String,
+    },
+
+    /// Digest algorithm is not supported.
+    #[error("unsupported digest algorithm: {algorithm}")]
+    UnsupportedAlgorithm {
+        /// The unsupported algorithm.
+        algorithm: String,
+    },
+
+    /// Computed digest doesn't match expected.
+    #[error("digest mismatch: expected {expected}, got {actual}")]
+    Mismatch {
+        /// Expected digest.
+        expected: String,
+        /// Actual computed digest.
+        actual: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_digest() {
+        let data = b"hello world";
+        let digest = compute_digest(data);
+
+        assert!(digest.starts_with("sha256:"));
+        assert_eq!(digest.len(), 7 + 64);
+        // Known SHA256 of "hello world"
+        assert_eq!(
+            digest,
+            "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+    }
+
+    #[test]
+    fn test_verify_digest_success() {
+        let data = b"hello world";
+        let expected = "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+        assert!(verify_digest(data, expected).is_ok());
+    }
+
+    #[test]
+    fn test_verify_digest_failure() {
+        let data = b"hello world";
+        let wrong = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+        assert!(verify_digest(data, wrong).is_err());
+    }
+
+    #[test]
+    fn test_parse_digest_valid() {
+        let digest = "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+        let result = parse_digest(digest);
+        assert!(result.is_ok());
+
+        let (algo, hash) = result.unwrap_or_else(|e| panic!("unexpected error: {e}"));
+        assert_eq!(algo, "sha256");
+        assert_eq!(hash.len(), 64);
+    }
+
+    #[test]
+    fn test_parse_digest_invalid_format() {
+        assert!(parse_digest("invalid").is_err());
+        assert!(parse_digest("sha256:tooshort").is_err());
+        assert!(parse_digest("md5:d41d8cd98f00b204e9800998ecf8427e").is_err());
+    }
+}

--- a/fabricks-oci/src/error.rs
+++ b/fabricks-oci/src/error.rs
@@ -1,0 +1,75 @@
+//! Error types for OCI registry operations.
+
+use thiserror::Error;
+
+/// Errors that can occur during OCI operations.
+#[derive(Debug, Error)]
+pub enum OciError {
+    /// The underlying OCI client returned an error.
+    #[error("OCI client error: {0}")]
+    ClientError(#[from] oci_client::errors::OciDistributionError),
+
+    /// JSON serialization/deserialization failed.
+    #[error("JSON error: {0}")]
+    JsonError(#[from] serde_json::Error),
+
+    /// IO operation failed.
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    /// Invalid image reference.
+    #[error("invalid image reference '{reference}': {reason}")]
+    InvalidReference {
+        /// The invalid reference.
+        reference: String,
+        /// Reason it's invalid.
+        reason: String,
+    },
+
+    /// Digest mismatch during verification.
+    #[error("digest mismatch: expected {expected}, got {actual}")]
+    DigestMismatch {
+        /// Expected digest.
+        expected: String,
+        /// Actual digest.
+        actual: String,
+    },
+
+    /// Module not found.
+    #[error("module not found: {reference}")]
+    ModuleNotFound {
+        /// The reference that wasn't found.
+        reference: String,
+    },
+
+    /// Unsupported media type in manifest.
+    #[error("unsupported media type: {media_type}")]
+    UnsupportedMediaType {
+        /// The unsupported media type.
+        media_type: String,
+    },
+
+    /// Invalid module: missing required layer.
+    #[error("invalid module: {reason}")]
+    InvalidModule {
+        /// Why the module is invalid.
+        reason: String,
+    },
+
+    /// Configuration parsing failed.
+    #[error("failed to parse config: {reason}")]
+    ConfigParseError {
+        /// Why parsing failed.
+        reason: String,
+    },
+
+    /// Local storage operation failed.
+    #[error("storage error: {reason}")]
+    StorageError {
+        /// Why the storage operation failed.
+        reason: String,
+    },
+}
+
+/// Result type for OCI operations.
+pub type Result<T> = std::result::Result<T, OciError>;

--- a/fabricks-oci/src/lib.rs
+++ b/fabricks-oci/src/lib.rs
@@ -1,21 +1,50 @@
 //! Fabricks OCI Registry Client
 //!
-//! Client library for interacting with OCI-compliant container registries.
+//! Client library for pushing and pulling Fabricks WASM modules to/from
+//! OCI-compliant container registries.
 //!
 //! # Features
 //!
 //! - Push and pull WASM modules as OCI artifacts
 //! - OAuth2/Bearer token authentication
-//! - Multi-registry credential management
-//! - Local OCI layout storage
+//! - Content verification with SHA256 digests
+//! - Support for major registries (Docker Hub, GHCR, ECR, GAR, ACR)
 //!
-//! # Supported Registries
+//! # Example
 //!
-//! - Docker Hub
-//! - GitHub Container Registry (GHCR)
-//! - Amazon ECR
-//! - Google Artifact Registry
-//! - Azure Container Registry
-//! - Any OCI Distribution Spec compliant registry
+//! ```no_run
+//! use fabricks_oci::client::FabricksClient;
+//! use fabricks_oci::module::FabricksModule;
+//! use oci_client::Reference;
+//! use oci_client::secrets::RegistryAuth;
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! // Create client
+//! let client = FabricksClient::new();
+//!
+//! // Parse reference
+//! let reference: Reference = "ghcr.io/user/my-module:1.0.0".parse()?;
+//!
+//! // Pull a module
+//! let pulled = client.pull(&reference, &RegistryAuth::Anonymous).await?;
+//! println!("Pulled module: {}", pulled.module.name());
+//! # Ok(())
+//! # }
+//! ```
 
-// Implementation will be added in Phase 3
+pub mod client;
+pub mod digest;
+pub mod error;
+pub mod media_types;
+pub mod module;
+pub mod storage;
+
+// Re-export commonly used types
+pub use client::{ClientConfig, FabricksClient};
+pub use error::{OciError, Result};
+pub use module::{FabricksModule, PulledModule};
+pub use storage::LocalStorage;
+
+// Re-export oci-client types for convenience
+pub use oci_client::secrets::RegistryAuth;
+pub use oci_client::Reference;

--- a/fabricks-oci/src/media_types.rs
+++ b/fabricks-oci/src/media_types.rs
@@ -1,0 +1,78 @@
+//! Fabricks-specific OCI media types.
+//!
+//! These media types follow the OCI artifact specification for custom content types.
+//! They allow OCI registries to distinguish Fabricks WASM modules from container images.
+
+/// Media type for the Fabricks module artifact.
+pub const ARTIFACT_TYPE: &str = "application/vnd.fabricks.module.v1";
+
+/// Media type for the Fabricks configuration (Fabrickfile as TOML).
+pub const CONFIG_MEDIA_TYPE: &str = "application/vnd.fabricks.config.v1+toml";
+
+/// Media type for the WASM module layer.
+pub const WASM_LAYER_MEDIA_TYPE: &str = "application/vnd.fabricks.module.v1+wasm";
+
+/// Media type for static files layer (gzipped tar).
+pub const FILES_LAYER_MEDIA_TYPE: &str = "application/vnd.fabricks.files.v1.tar+gzip";
+
+/// OCI manifest media type.
+pub const MANIFEST_MEDIA_TYPE: &str = "application/vnd.oci.image.manifest.v1+json";
+
+/// OCI image index (manifest list) media type.
+pub const INDEX_MEDIA_TYPE: &str = "application/vnd.oci.image.index.v1+json";
+
+/// Empty config media type (used when config is embedded in annotations).
+pub const EMPTY_CONFIG_MEDIA_TYPE: &str = "application/vnd.oci.empty.v1+json";
+
+/// Annotation key for the Fabricks version.
+pub const ANNOTATION_FABRICK_VERSION: &str = "dev.fabricks.version";
+
+/// Annotation key for the module name.
+pub const ANNOTATION_NAME: &str = "dev.fabricks.name";
+
+/// Annotation key for the module version.
+pub const ANNOTATION_VERSION: &str = "dev.fabricks.module.version";
+
+/// Annotation key for the module description.
+pub const ANNOTATION_DESCRIPTION: &str = "org.opencontainers.image.description";
+
+/// Annotation key for authors.
+pub const ANNOTATION_AUTHORS: &str = "org.opencontainers.image.authors";
+
+/// Annotation key for license.
+pub const ANNOTATION_LICENSE: &str = "org.opencontainers.image.licenses";
+
+/// Annotation key for source repository.
+pub const ANNOTATION_SOURCE: &str = "org.opencontainers.image.source";
+
+/// Annotation key for creation timestamp.
+pub const ANNOTATION_CREATED: &str = "org.opencontainers.image.created";
+
+/// Check if a media type is a Fabricks WASM module.
+#[must_use]
+pub fn is_fabricks_module(media_type: &str) -> bool {
+    media_type == WASM_LAYER_MEDIA_TYPE
+}
+
+/// Check if a media type is a Fabricks config.
+#[must_use]
+pub fn is_fabricks_config(media_type: &str) -> bool {
+    media_type == CONFIG_MEDIA_TYPE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_fabricks_module() {
+        assert!(is_fabricks_module(WASM_LAYER_MEDIA_TYPE));
+        assert!(!is_fabricks_module("application/octet-stream"));
+    }
+
+    #[test]
+    fn test_is_fabricks_config() {
+        assert!(is_fabricks_config(CONFIG_MEDIA_TYPE));
+        assert!(!is_fabricks_config("application/json"));
+    }
+}

--- a/fabricks-oci/src/module.rs
+++ b/fabricks-oci/src/module.rs
@@ -1,0 +1,238 @@
+//! Fabricks module representation for OCI artifacts.
+//!
+//! A `FabricksModule` bundles a WASM binary with its Fabrickfile configuration
+//! and optional static files for distribution via OCI registries.
+
+use std::collections::HashMap;
+
+use fabricks_common::Fabrickfile;
+
+use crate::digest::compute_digest;
+use crate::media_types;
+
+/// A Fabricks module ready for OCI distribution.
+///
+/// Contains the WASM binary, configuration, and metadata needed to push
+/// to an OCI registry or run locally.
+#[derive(Debug, Clone)]
+pub struct FabricksModule {
+    /// The Fabrickfile configuration.
+    config: Fabrickfile,
+
+    /// The compiled WASM binary.
+    wasm_bytes: Vec<u8>,
+
+    /// Optional static files to include (path -> contents).
+    files: Option<HashMap<String, Vec<u8>>>,
+
+    /// Additional annotations for the manifest.
+    annotations: HashMap<String, String>,
+}
+
+impl FabricksModule {
+    /// Create a new Fabricks module.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - The Fabrickfile configuration
+    /// * `wasm_bytes` - The compiled WASM binary
+    #[must_use]
+    pub fn new(config: Fabrickfile, wasm_bytes: Vec<u8>) -> Self {
+        Self {
+            config,
+            wasm_bytes,
+            files: None,
+            annotations: HashMap::new(),
+        }
+    }
+
+    /// Add static files to include with the module.
+    #[must_use]
+    pub fn with_files(mut self, files: HashMap<String, Vec<u8>>) -> Self {
+        self.files = Some(files);
+        self
+    }
+
+    /// Add custom annotations to the manifest.
+    #[must_use]
+    pub fn with_annotation(mut self, key: String, value: String) -> Self {
+        self.annotations.insert(key, value);
+        self
+    }
+
+    /// Get the module name from the config.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.config.info.name
+    }
+
+    /// Get the module version from the config.
+    #[must_use]
+    pub fn version(&self) -> &str {
+        &self.config.info.version
+    }
+
+    /// Get the Fabrickfile configuration.
+    #[must_use]
+    pub const fn config(&self) -> &Fabrickfile {
+        &self.config
+    }
+
+    /// Get the WASM bytes.
+    #[must_use]
+    pub fn wasm_bytes(&self) -> &[u8] {
+        &self.wasm_bytes
+    }
+
+    /// Get the static files, if any.
+    #[must_use]
+    pub const fn files(&self) -> Option<&HashMap<String, Vec<u8>>> {
+        self.files.as_ref()
+    }
+
+    /// Compute the digest of the WASM binary.
+    #[must_use]
+    pub fn wasm_digest(&self) -> String {
+        compute_digest(&self.wasm_bytes)
+    }
+
+    /// Get the size of the WASM binary in bytes.
+    #[must_use]
+    pub fn wasm_size(&self) -> usize {
+        self.wasm_bytes.len()
+    }
+
+    /// Serialize the config to TOML bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if TOML serialization fails.
+    pub fn config_bytes(&self) -> Result<Vec<u8>, toml::ser::Error> {
+        let toml_str = toml::to_string_pretty(&self.config)?;
+        Ok(toml_str.into_bytes())
+    }
+
+    /// Build the annotations map for the OCI manifest.
+    #[must_use]
+    pub fn build_annotations(&self) -> HashMap<String, String> {
+        let mut annotations = self.annotations.clone();
+
+        // Add standard Fabricks annotations
+        annotations.insert(
+            media_types::ANNOTATION_FABRICK_VERSION.to_string(),
+            self.config.fabrick_version.clone(),
+        );
+        annotations.insert(
+            media_types::ANNOTATION_NAME.to_string(),
+            self.config.info.name.clone(),
+        );
+        annotations.insert(
+            media_types::ANNOTATION_VERSION.to_string(),
+            self.config.info.version.clone(),
+        );
+
+        // Add optional metadata
+        if let Some(ref desc) = self.config.info.description {
+            annotations.insert(media_types::ANNOTATION_DESCRIPTION.to_string(), desc.clone());
+        }
+
+        if let Some(ref authors) = self.config.info.authors {
+            annotations.insert(
+                media_types::ANNOTATION_AUTHORS.to_string(),
+                authors.join(", "),
+            );
+        }
+
+        if let Some(ref license) = self.config.info.license {
+            annotations.insert(media_types::ANNOTATION_LICENSE.to_string(), license.clone());
+        }
+
+        if let Some(ref repo) = self.config.info.repository {
+            annotations.insert(media_types::ANNOTATION_SOURCE.to_string(), repo.clone());
+        }
+
+        annotations
+    }
+}
+
+/// A pulled Fabricks module with its manifest digest.
+#[derive(Debug, Clone)]
+pub struct PulledModule {
+    /// The module contents.
+    pub module: FabricksModule,
+
+    /// The manifest digest from the registry.
+    pub digest: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fabricks_common::models::fabrickfile::Info;
+    use fabricks_common::Capabilities;
+
+    fn test_config() -> Fabrickfile {
+        Fabrickfile {
+            fabrick_version: "1.0".to_string(),
+            info: Info {
+                name: "test-module".to_string(),
+                version: "1.0.0".to_string(),
+                description: Some("A test module".to_string()),
+                authors: Some(vec!["Test Author".to_string()]),
+                license: Some("MIT".to_string()),
+                homepage: None,
+                repository: Some("https://github.com/example/test".to_string()),
+                documentation: None,
+                keywords: None,
+            },
+            from: None,
+            source: None,
+            runtime: None,
+            build: None,
+            exports: None,
+            imports: None,
+            capabilities: Capabilities::default(),
+            files: None,
+            config: None,
+            health_check: None,
+            security: None,
+            labels: None,
+            validate: None,
+        }
+    }
+
+    #[test]
+    fn test_module_creation() {
+        let wasm = vec![0x00, 0x61, 0x73, 0x6d]; // WASM magic bytes
+        let module = FabricksModule::new(test_config(), wasm);
+
+        assert_eq!(module.name(), "test-module");
+        assert_eq!(module.version(), "1.0.0");
+        assert_eq!(module.wasm_size(), 4);
+    }
+
+    #[test]
+    fn test_module_digest() {
+        let wasm = b"test wasm content".to_vec();
+        let module = FabricksModule::new(test_config(), wasm);
+
+        let digest = module.wasm_digest();
+        assert!(digest.starts_with("sha256:"));
+    }
+
+    #[test]
+    fn test_build_annotations() {
+        let module = FabricksModule::new(test_config(), vec![]);
+        let annotations = module.build_annotations();
+
+        assert_eq!(annotations.get(media_types::ANNOTATION_NAME), Some(&"test-module".to_string()));
+        assert_eq!(
+            annotations.get(media_types::ANNOTATION_VERSION),
+            Some(&"1.0.0".to_string())
+        );
+        assert_eq!(
+            annotations.get(media_types::ANNOTATION_DESCRIPTION),
+            Some(&"A test module".to_string())
+        );
+    }
+}

--- a/fabricks-oci/src/storage.rs
+++ b/fabricks-oci/src/storage.rs
@@ -1,0 +1,506 @@
+//! Local OCI layout storage for caching and offline access.
+//!
+//! Implements the OCI Image Layout specification for storing pulled modules
+//! locally and providing cache functionality.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+
+use crate::digest::{compute_digest, verify_digest};
+use crate::error::{OciError, Result};
+
+/// OCI layout version.
+const OCI_LAYOUT_VERSION: &str = "1.0.0";
+
+/// Local storage implementing OCI Image Layout specification.
+///
+/// Directory structure:
+/// ```text
+/// <base_path>/
+/// ├── oci-layout              # Layout version file
+/// ├── index.json              # Image index
+/// └── blobs/
+///     └── sha256/
+///         ├── <config_hash>   # Config blob
+///         ├── <wasm_hash>     # WASM layer blob
+///         └── <manifest_hash> # Manifest blob
+/// ```
+pub struct LocalStorage {
+    /// Base path for OCI layout storage.
+    base_path: PathBuf,
+}
+
+/// OCI layout version file content.
+#[derive(Debug, Serialize, Deserialize)]
+struct OciLayout {
+    #[serde(rename = "imageLayoutVersion")]
+    image_layout_version: String,
+}
+
+/// OCI image index.
+#[derive(Debug, Serialize, Deserialize)]
+struct ImageIndex {
+    #[serde(rename = "schemaVersion")]
+    schema_version: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    manifests: Option<Vec<IndexManifest>>,
+}
+
+/// A manifest reference in the image index.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct IndexManifest {
+    #[serde(rename = "mediaType")]
+    media_type: String,
+    digest: String,
+    size: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    annotations: Option<BTreeMap<String, String>>,
+}
+
+impl LocalStorage {
+    /// Create a new local storage at the given path.
+    ///
+    /// Creates the directory structure if it doesn't exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if directory creation fails.
+    pub async fn new(base_path: impl Into<PathBuf>) -> Result<Self> {
+        let base_path = base_path.into();
+        let storage = Self { base_path };
+        storage.init().await?;
+        Ok(storage)
+    }
+
+    /// Open existing storage without initializing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the storage doesn't exist or is invalid.
+    pub fn open(base_path: impl Into<PathBuf>) -> Result<Self> {
+        let base_path = base_path.into();
+
+        // Verify oci-layout file exists
+        let layout_path = base_path.join("oci-layout");
+        if !layout_path.exists() {
+            return Err(OciError::StorageError {
+                reason: format!("not an OCI layout: {}", base_path.display()),
+            });
+        }
+
+        Ok(Self { base_path })
+    }
+
+    /// Initialize the OCI layout directory structure.
+    async fn init(&self) -> Result<()> {
+        // Create directories
+        fs::create_dir_all(self.blobs_dir()).await.map_err(|e| OciError::StorageError {
+            reason: format!("failed to create blobs directory: {e}"),
+        })?;
+
+        // Write oci-layout file
+        let layout = OciLayout {
+            image_layout_version: OCI_LAYOUT_VERSION.to_string(),
+        };
+        let layout_json =
+            serde_json::to_string_pretty(&layout).map_err(|e| OciError::StorageError {
+                reason: format!("failed to serialize oci-layout: {e}"),
+            })?;
+        fs::write(self.base_path.join("oci-layout"), layout_json)
+            .await
+            .map_err(|e| OciError::StorageError {
+                reason: format!("failed to write oci-layout: {e}"),
+            })?;
+
+        // Initialize empty index if it doesn't exist
+        let index_path = self.base_path.join("index.json");
+        if !index_path.exists() {
+            let index = ImageIndex {
+                schema_version: 2,
+                manifests: Some(Vec::new()),
+            };
+            let index_json =
+                serde_json::to_string_pretty(&index).map_err(|e| OciError::StorageError {
+                    reason: format!("failed to serialize index: {e}"),
+                })?;
+            fs::write(&index_path, index_json)
+                .await
+                .map_err(|e| OciError::StorageError {
+                    reason: format!("failed to write index.json: {e}"),
+                })?;
+        }
+
+        Ok(())
+    }
+
+    /// Get the blobs directory path.
+    fn blobs_dir(&self) -> PathBuf {
+        self.base_path.join("blobs/sha256")
+    }
+
+    /// Store a blob and return its digest.
+    ///
+    /// The blob is content-addressed by its SHA256 digest.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the write fails.
+    pub async fn store_blob(&self, data: &[u8]) -> Result<String> {
+        let digest = compute_digest(data);
+        let hash = digest
+            .strip_prefix("sha256:")
+            .ok_or_else(|| OciError::StorageError {
+                reason: "invalid digest format".to_string(),
+            })?;
+
+        let blob_path = self.blobs_dir().join(hash);
+
+        // Skip if already exists (content-addressed)
+        if blob_path.exists() {
+            return Ok(digest);
+        }
+
+        // Write atomically using temp file
+        let temp_path = self.blobs_dir().join(format!("{hash}.tmp"));
+        let mut file = fs::File::create(&temp_path)
+            .await
+            .map_err(|e| OciError::StorageError {
+                reason: format!("failed to create temp file: {e}"),
+            })?;
+
+        file.write_all(data)
+            .await
+            .map_err(|e| OciError::StorageError {
+                reason: format!("failed to write blob: {e}"),
+            })?;
+
+        file.sync_all()
+            .await
+            .map_err(|e| OciError::StorageError {
+                reason: format!("failed to sync blob: {e}"),
+            })?;
+
+        fs::rename(&temp_path, &blob_path)
+            .await
+            .map_err(|e| OciError::StorageError {
+                reason: format!("failed to rename blob: {e}"),
+            })?;
+
+        Ok(digest)
+    }
+
+    /// Get a blob by its digest.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the blob doesn't exist or verification fails.
+    pub async fn get_blob(&self, digest: &str) -> Result<Vec<u8>> {
+        let hash = digest
+            .strip_prefix("sha256:")
+            .ok_or_else(|| OciError::StorageError {
+                reason: format!("invalid digest format: {digest}"),
+            })?;
+
+        let blob_path = self.blobs_dir().join(hash);
+
+        let data = fs::read(&blob_path)
+            .await
+            .map_err(|e| OciError::StorageError {
+                reason: format!("failed to read blob {digest}: {e}"),
+            })?;
+
+        // Verify content integrity
+        verify_digest(&data, digest).map_err(|e| OciError::StorageError {
+            reason: format!("blob verification failed: {e}"),
+        })?;
+
+        Ok(data)
+    }
+
+    /// Check if a blob exists.
+    #[must_use]
+    pub fn has_blob(&self, digest: &str) -> bool {
+        let Some(hash) = digest.strip_prefix("sha256:") else {
+            return false;
+        };
+        self.blobs_dir().join(hash).exists()
+    }
+
+    /// Delete a blob by its digest.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if deletion fails.
+    pub async fn delete_blob(&self, digest: &str) -> Result<()> {
+        let hash = digest
+            .strip_prefix("sha256:")
+            .ok_or_else(|| OciError::StorageError {
+                reason: format!("invalid digest format: {digest}"),
+            })?;
+
+        let blob_path = self.blobs_dir().join(hash);
+        if blob_path.exists() {
+            fs::remove_file(&blob_path)
+                .await
+                .map_err(|e| OciError::StorageError {
+                    reason: format!("failed to delete blob: {e}"),
+                })?;
+        }
+
+        Ok(())
+    }
+
+    /// Add a manifest to the index with a reference tag.
+    ///
+    /// # Arguments
+    ///
+    /// * `reference` - The image reference (e.g., "mymodule:1.0.0")
+    /// * `manifest_digest` - The digest of the manifest blob
+    /// * `manifest_size` - Size of the manifest in bytes
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if updating the index fails.
+    pub async fn add_to_index(
+        &self,
+        reference: &str,
+        manifest_digest: &str,
+        manifest_size: i64,
+    ) -> Result<()> {
+        let index_path = self.base_path.join("index.json");
+        let index_content = fs::read_to_string(&index_path)
+            .await
+            .map_err(|e| OciError::StorageError {
+                reason: format!("failed to read index: {e}"),
+            })?;
+
+        let mut index: ImageIndex =
+            serde_json::from_str(&index_content).map_err(|e| OciError::StorageError {
+                reason: format!("failed to parse index: {e}"),
+            })?;
+
+        let manifests = index.manifests.get_or_insert_with(Vec::new);
+
+        // Remove existing entry for this reference
+        manifests.retain(|m| {
+            m.annotations
+                .as_ref()
+                .and_then(|a| a.get("org.opencontainers.image.ref.name"))
+                != Some(&reference.to_string())
+        });
+
+        // Add new entry
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            "org.opencontainers.image.ref.name".to_string(),
+            reference.to_string(),
+        );
+
+        manifests.push(IndexManifest {
+            media_type: "application/vnd.oci.image.manifest.v1+json".to_string(),
+            digest: manifest_digest.to_string(),
+            size: manifest_size,
+            annotations: Some(annotations),
+        });
+
+        // Write updated index
+        let index_json =
+            serde_json::to_string_pretty(&index).map_err(|e| OciError::StorageError {
+                reason: format!("failed to serialize index: {e}"),
+            })?;
+
+        fs::write(&index_path, index_json)
+            .await
+            .map_err(|e| OciError::StorageError {
+                reason: format!("failed to write index: {e}"),
+            })?;
+
+        Ok(())
+    }
+
+    /// Look up a manifest digest by reference.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the reference is not found.
+    pub async fn get_manifest_digest(&self, reference: &str) -> Result<String> {
+        let index_path = self.base_path.join("index.json");
+        let index_content = fs::read_to_string(&index_path)
+            .await
+            .map_err(|e| OciError::StorageError {
+                reason: format!("failed to read index: {e}"),
+            })?;
+
+        let index: ImageIndex =
+            serde_json::from_str(&index_content).map_err(|e| OciError::StorageError {
+                reason: format!("failed to parse index: {e}"),
+            })?;
+
+        let manifests = index.manifests.as_ref().ok_or_else(|| OciError::StorageError {
+            reason: "index has no manifests".to_string(),
+        })?;
+
+        for manifest in manifests {
+            if let Some(annotations) = &manifest.annotations
+                && annotations.get("org.opencontainers.image.ref.name")
+                    == Some(&reference.to_string())
+            {
+                return Ok(manifest.digest.clone());
+            }
+        }
+
+        Err(OciError::StorageError {
+            reason: format!("reference not found: {reference}"),
+        })
+    }
+
+    /// List all references in the index.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if reading the index fails.
+    pub async fn list_references(&self) -> Result<Vec<String>> {
+        let index_path = self.base_path.join("index.json");
+        let index_content = fs::read_to_string(&index_path)
+            .await
+            .map_err(|e| OciError::StorageError {
+                reason: format!("failed to read index: {e}"),
+            })?;
+
+        let index: ImageIndex =
+            serde_json::from_str(&index_content).map_err(|e| OciError::StorageError {
+                reason: format!("failed to parse index: {e}"),
+            })?;
+
+        let mut refs = Vec::new();
+        if let Some(manifests) = index.manifests {
+            for manifest in manifests {
+                if let Some(annotations) = manifest.annotations
+                    && let Some(name) = annotations.get("org.opencontainers.image.ref.name")
+                {
+                    refs.push(name.clone());
+                }
+            }
+        }
+
+        Ok(refs)
+    }
+
+    /// Get the base path of the storage.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.base_path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_storage_init() {
+        let temp = TempDir::new().expect("Failed to create temp directory");
+        let storage = LocalStorage::new(temp.path()).await.expect("Failed to create storage");
+
+        assert!(temp.path().join("oci-layout").exists());
+        assert!(temp.path().join("index.json").exists());
+        assert!(temp.path().join("blobs/sha256").exists());
+        assert_eq!(storage.path(), temp.path());
+    }
+
+    #[tokio::test]
+    async fn test_store_and_get_blob() {
+        let temp = TempDir::new().expect("Failed to create temp directory");
+        let storage = LocalStorage::new(temp.path()).await.expect("Failed to create storage");
+
+        let data = b"hello world";
+        let digest = storage.store_blob(data).await.expect("Failed to store blob");
+
+        assert!(digest.starts_with("sha256:"));
+        assert!(storage.has_blob(&digest));
+
+        let retrieved = storage.get_blob(&digest).await.expect("Failed to get blob");
+        assert_eq!(retrieved, data);
+    }
+
+    #[tokio::test]
+    async fn test_blob_deduplication() {
+        let temp = TempDir::new().expect("Failed to create temp directory");
+        let storage = LocalStorage::new(temp.path()).await.expect("Failed to create storage");
+
+        let data = b"duplicate content";
+        let digest1 = storage.store_blob(data).await.expect("Failed to store blob");
+        let digest2 = storage.store_blob(data).await.expect("Failed to store blob");
+
+        assert_eq!(digest1, digest2);
+    }
+
+    #[tokio::test]
+    async fn test_delete_blob() {
+        let temp = TempDir::new().expect("Failed to create temp directory");
+        let storage = LocalStorage::new(temp.path()).await.expect("Failed to create storage");
+
+        let data = b"to be deleted";
+        let digest = storage.store_blob(data).await.expect("Failed to store blob");
+
+        assert!(storage.has_blob(&digest));
+
+        storage.delete_blob(&digest).await.expect("Failed to delete blob");
+
+        assert!(!storage.has_blob(&digest));
+    }
+
+    #[tokio::test]
+    async fn test_index_operations() {
+        let temp = TempDir::new().expect("Failed to create temp directory");
+        let storage = LocalStorage::new(temp.path()).await.expect("Failed to create storage");
+
+        let digest = "sha256:abc123def456abc123def456abc123def456abc123def456abc123def456abc1";
+
+        storage
+            .add_to_index("mymodule:1.0.0", digest, 1234)
+            .await
+            .expect("Failed to add to index");
+
+        let refs = storage.list_references().await.expect("Failed to list references");
+        assert!(refs.contains(&"mymodule:1.0.0".to_string()));
+
+        let found_digest = storage
+            .get_manifest_digest("mymodule:1.0.0")
+            .await
+            .expect("Failed to get digest");
+        assert_eq!(found_digest, digest);
+    }
+
+    #[tokio::test]
+    async fn test_index_update_same_reference() {
+        let temp = TempDir::new().expect("Failed to create temp directory");
+        let storage = LocalStorage::new(temp.path()).await.expect("Failed to create storage");
+
+        let digest1 = "sha256:111111111111111111111111111111111111111111111111111111111111111a";
+        let digest2 = "sha256:222222222222222222222222222222222222222222222222222222222222222b";
+
+        storage
+            .add_to_index("mymodule:latest", digest1, 100)
+            .await
+            .expect("Failed to add first");
+        storage
+            .add_to_index("mymodule:latest", digest2, 200)
+            .await
+            .expect("Failed to add second");
+
+        let refs = storage.list_references().await.expect("Failed to list");
+        assert_eq!(refs.len(), 1);
+
+        let found = storage
+            .get_manifest_digest("mymodule:latest")
+            .await
+            .expect("Failed to get digest");
+        assert_eq!(found, digest2);
+    }
+}

--- a/fabricks-oci/tests/registry_integration.rs
+++ b/fabricks-oci/tests/registry_integration.rs
@@ -1,0 +1,286 @@
+//! Integration tests for OCI registry operations.
+//!
+//! These tests require a real OCI registry to run. Set the following environment
+//! variables to enable them:
+//!
+//! - `FABRICKS_TEST_REGISTRY`: Registry URL (e.g., "registry.ldllc.dev")
+//! - `FABRICKS_TEST_REGISTRY_USER`: (optional) Username for authentication
+//! - `FABRICKS_TEST_REGISTRY_PASSWORD`: (optional) Password for authentication
+//!
+//! Example:
+//! ```bash
+//! FABRICKS_TEST_REGISTRY=registry.ldllc.dev cargo test -p fabricks-oci --test registry_integration
+//! ```
+
+use std::env;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use fabricks_common::models::fabrickfile::Info;
+use fabricks_common::{Capabilities, Fabrickfile};
+use fabricks_oci::{FabricksClient, FabricksModule, Reference, RegistryAuth};
+
+/// Get the test registry URL from environment.
+fn get_registry() -> Option<String> {
+    env::var("FABRICKS_TEST_REGISTRY").ok()
+}
+
+/// Get registry authentication from environment.
+fn get_auth() -> RegistryAuth {
+    match (
+        env::var("FABRICKS_TEST_REGISTRY_USER"),
+        env::var("FABRICKS_TEST_REGISTRY_PASSWORD"),
+    ) {
+        (Ok(user), Ok(pass)) => RegistryAuth::Basic(user, pass),
+        _ => RegistryAuth::Anonymous,
+    }
+}
+
+/// Create a test Fabrickfile configuration.
+fn test_config(name: &str, version: &str) -> Fabrickfile {
+    Fabrickfile {
+        fabrick_version: "1.0".to_string(),
+        info: Info {
+            name: name.to_string(),
+            version: version.to_string(),
+            description: Some("Integration test module".to_string()),
+            authors: Some(vec!["Test Author".to_string()]),
+            license: Some("MIT".to_string()),
+            homepage: None,
+            repository: Some("https://github.com/example/test".to_string()),
+            documentation: None,
+            keywords: Some(vec!["test".to_string(), "integration".to_string()]),
+        },
+        from: None,
+        source: None,
+        runtime: None,
+        build: None,
+        exports: None,
+        imports: None,
+        capabilities: Capabilities::default(),
+        files: None,
+        config: None,
+        health_check: None,
+        security: None,
+        labels: None,
+        validate: None,
+    }
+}
+
+/// Generate a unique tag for test isolation.
+fn unique_tag() -> String {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    format!("test-{timestamp}")
+}
+
+/// Create a minimal valid WASM module (just the magic bytes + version).
+fn minimal_wasm() -> Vec<u8> {
+    // Minimal valid WASM: magic number (0x00 0x61 0x73 0x6d) + version (0x01 0x00 0x00 0x00)
+    vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]
+}
+
+#[tokio::test]
+async fn test_push_and_pull_module() {
+    let Some(registry) = get_registry() else {
+        eprintln!("Skipping test: FABRICKS_TEST_REGISTRY not set");
+        return;
+    };
+
+    let auth = get_auth();
+    let client = FabricksClient::new();
+
+    let tag = unique_tag();
+    let reference: Reference = format!("{registry}/fabricks-test/hello:{tag}")
+        .parse()
+        .expect("Invalid reference");
+
+    // Create test module
+    let config = test_config("hello", "1.0.0");
+    let wasm = minimal_wasm();
+    let module = FabricksModule::new(config, wasm.clone());
+
+    // Push module
+    let manifest_url = client
+        .push(&reference, &module, &auth)
+        .await
+        .expect("Failed to push module");
+
+    println!("Pushed to: {manifest_url}");
+    assert!(!manifest_url.is_empty());
+
+    // Pull module back
+    let pulled = client
+        .pull(&reference, &auth)
+        .await
+        .expect("Failed to pull module");
+
+    assert_eq!(pulled.module.name(), "hello");
+    assert_eq!(pulled.module.version(), "1.0.0");
+    assert_eq!(pulled.module.wasm_bytes(), wasm.as_slice());
+    assert!(!pulled.digest.is_empty());
+}
+
+#[tokio::test]
+async fn test_module_exists() {
+    let Some(registry) = get_registry() else {
+        eprintln!("Skipping test: FABRICKS_TEST_REGISTRY not set");
+        return;
+    };
+
+    let auth = get_auth();
+    let client = FabricksClient::new();
+
+    let tag = unique_tag();
+    let reference: Reference = format!("{registry}/fabricks-test/exists-test:{tag}")
+        .parse()
+        .expect("Invalid reference");
+
+    // Should not exist initially
+    let exists_before = client
+        .exists(&reference, &auth)
+        .await
+        .expect("Failed to check existence");
+    assert!(!exists_before, "Module should not exist before push");
+
+    // Push module
+    let config = test_config("exists-test", "1.0.0");
+    let module = FabricksModule::new(config, minimal_wasm());
+    client
+        .push(&reference, &module, &auth)
+        .await
+        .expect("Failed to push module");
+
+    // Should exist now
+    let exists_after = client
+        .exists(&reference, &auth)
+        .await
+        .expect("Failed to check existence");
+    assert!(exists_after, "Module should exist after push");
+}
+
+#[tokio::test]
+async fn test_list_tags() {
+    let Some(registry) = get_registry() else {
+        eprintln!("Skipping test: FABRICKS_TEST_REGISTRY not set");
+        return;
+    };
+
+    let auth = get_auth();
+    let client = FabricksClient::new();
+
+    let base_tag = unique_tag();
+    let tag1 = format!("{base_tag}-v1");
+    let tag2 = format!("{base_tag}-v2");
+
+    let ref1: Reference = format!("{registry}/fabricks-test/tags-test:{tag1}")
+        .parse()
+        .expect("Invalid reference");
+    let ref2: Reference = format!("{registry}/fabricks-test/tags-test:{tag2}")
+        .parse()
+        .expect("Invalid reference");
+
+    // Push two versions
+    let config1 = test_config("tags-test", "1.0.0");
+    let module1 = FabricksModule::new(config1, minimal_wasm());
+    client
+        .push(&ref1, &module1, &auth)
+        .await
+        .expect("Failed to push v1");
+
+    let config2 = test_config("tags-test", "2.0.0");
+    let module2 = FabricksModule::new(config2, minimal_wasm());
+    client
+        .push(&ref2, &module2, &auth)
+        .await
+        .expect("Failed to push v2");
+
+    // List tags
+    let tags = client
+        .list_tags(&ref1, &auth)
+        .await
+        .expect("Failed to list tags");
+
+    println!("Found tags: {tags:?}");
+    assert!(tags.contains(&tag1), "Should contain first tag");
+    assert!(tags.contains(&tag2), "Should contain second tag");
+}
+
+#[tokio::test]
+async fn test_push_with_annotations() {
+    let Some(registry) = get_registry() else {
+        eprintln!("Skipping test: FABRICKS_TEST_REGISTRY not set");
+        return;
+    };
+
+    let auth = get_auth();
+    let client = FabricksClient::new();
+
+    let tag = unique_tag();
+    let reference: Reference = format!("{registry}/fabricks-test/annotated:{tag}")
+        .parse()
+        .expect("Invalid reference");
+
+    // Create module with custom annotation
+    let config = test_config("annotated", "1.0.0");
+    let module = FabricksModule::new(config, minimal_wasm())
+        .with_annotation("custom.key".to_string(), "custom-value".to_string());
+
+    // Push and pull
+    client
+        .push(&reference, &module, &auth)
+        .await
+        .expect("Failed to push");
+
+    let pulled = client
+        .pull(&reference, &auth)
+        .await
+        .expect("Failed to pull");
+
+    // Verify metadata survived round-trip
+    assert_eq!(pulled.module.name(), "annotated");
+    assert_eq!(pulled.module.version(), "1.0.0");
+    assert_eq!(
+        pulled.module.config().info.description,
+        Some("Integration test module".to_string())
+    );
+}
+
+#[tokio::test]
+async fn test_content_integrity() {
+    let Some(registry) = get_registry() else {
+        eprintln!("Skipping test: FABRICKS_TEST_REGISTRY not set");
+        return;
+    };
+
+    let auth = get_auth();
+    let client = FabricksClient::new();
+
+    let tag = unique_tag();
+    let reference: Reference = format!("{registry}/fabricks-test/integrity:{tag}")
+        .parse()
+        .expect("Invalid reference");
+
+    // Create module with specific content
+    let wasm_content = b"This is test WASM content for integrity verification";
+    let config = test_config("integrity", "1.0.0");
+    let module = FabricksModule::new(config, wasm_content.to_vec());
+
+    let original_digest = module.wasm_digest();
+
+    // Push and pull
+    client
+        .push(&reference, &module, &auth)
+        .await
+        .expect("Failed to push");
+
+    let pulled = client
+        .pull(&reference, &auth)
+        .await
+        .expect("Failed to pull");
+
+    // Verify content is identical
+    assert_eq!(pulled.module.wasm_bytes(), wasm_content);
+    assert_eq!(pulled.module.wasm_digest(), original_digest);
+}


### PR DESCRIPTION
## Summary

Implements Phase 3 of the implementation plan: OCI Registry Client for pushing and pulling Fabricks WASM modules to/from OCI-compliant container registries.

### Key Features

- **FabricksClient**: High-level API wrapping `oci-client` for registry operations
  - `push()` - Push WASM modules with config and annotations
  - `pull()` - Pull modules and reconstruct Fabrickfile
  - `exists()` - Check if a module exists
  - `list_tags()` - List available tags for an image

- **FabricksModule**: Bundles WASM binary + Fabrickfile config for distribution
  - Content-addressed via SHA256 digests
  - Custom annotations for metadata

- **Media Types**: Fabricks-specific OCI media types
  - `application/vnd.fabricks.module.v1` - Artifact type
  - `application/vnd.fabricks.config.v1+toml` - Config layer
  - `application/vnd.fabricks.module.v1+wasm` - WASM layer
  - `dev.fabricks.*` annotations

- **LocalStorage**: OCI Image Layout for local caching
  - Store/retrieve blobs by digest
  - Index management for references
  - Content integrity verification

- **Integration Tests**: Validated against real Zot registry (registry.ldllc.dev)

### Phase 3 Success Criteria

- [x] Can push WASM module to OCI Registry
- [x] Can pull WASM module from OCI Registry
- [x] Content verification (SHA256) works
- [x] Local caching works
- [x] Authentication with major registries works (Basic + Anonymous)
- [x] Integration tests with test registry

## Test Plan

- [x] Unit tests pass: `cargo test -p fabricks-oci` (16 tests)
- [x] Integration tests pass against real registry
- [x] Clippy clean with pedantic lints
- [x] Full workspace build/test/clippy passes