### PR TITLE
Implement Phase 6: Daemon Foundation

### DIFF
--- a/fabricks/Cargo.toml
+++ b/fabricks/Cargo.toml
@@ -34,6 +34,10 @@ tracing-subscriber.workspace = true
 rpassword.workspace = true
 keyring.workspace = true
 dirs.workspace = true
+hyper.workspace = true
+hyper-util.workspace = true
+http-body-util.workspace = true
+tower.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/fabricks/src/cli.rs
+++ b/fabricks/src/cli.rs
@@ -2,7 +2,7 @@
 
 use std::path::PathBuf;
 
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 
 /// Fabricks - Declarative WASM Orchestration Platform.
 ///
@@ -67,6 +67,11 @@ pub enum Commands {
 
     /// Show version information.
     Version,
+
+    /// Daemon management commands.
+    ///
+    /// Interact with the fabricksd daemon.
+    Daemon(DaemonArgs),
 }
 
 /// Arguments for the build command.
@@ -238,4 +243,30 @@ pub enum OutputFormat {
     Text,
     /// JSON output for programmatic consumption.
     Json,
+}
+
+/// Arguments for daemon commands.
+#[derive(Args, Debug)]
+pub struct DaemonArgs {
+    #[command(subcommand)]
+    pub command: DaemonCommands,
+}
+
+/// Daemon subcommands.
+#[derive(Subcommand, Debug)]
+pub enum DaemonCommands {
+    /// Show daemon information.
+    ///
+    /// Displays version, uptime, and configuration of the running daemon.
+    Info {
+        /// Output format.
+        #[arg(short, long, value_enum, default_value = "text")]
+        format: OutputFormat,
+
+        /// Custom socket path.
+        ///
+        /// Override the default Unix socket path.
+        #[arg(long)]
+        socket: Option<PathBuf>,
+    },
 }

--- a/fabricks/src/commands/daemon.rs
+++ b/fabricks/src/commands/daemon.rs
@@ -1,0 +1,47 @@
+//! Daemon command implementation.
+
+use anyhow::Result;
+
+use crate::cli::{DaemonArgs, DaemonCommands, OutputFormat};
+use crate::daemon_client::DaemonClient;
+use crate::output;
+
+/// Runs the daemon command.
+///
+/// # Errors
+///
+/// Returns an error if the daemon command fails.
+pub async fn run(args: &DaemonArgs) -> Result<()> {
+    match &args.command {
+        DaemonCommands::Info { format, socket } => {
+            let client = match socket {
+                Some(path) => DaemonClient::with_socket(path.clone()),
+                None => DaemonClient::new(),
+            };
+
+            let info = client.info().await?;
+
+            match format {
+                OutputFormat::Json => {
+                    let json = serde_json::to_string_pretty(&info)?;
+                    output::writeln(&json)?;
+                }
+                OutputFormat::Text => {
+                    output::writeln(&format!("Version:     {}", info.version))?;
+                    output::writeln(&format!("API Version: {}", info.api_version))?;
+                    output::writeln(&format!("Runtime:     {}", info.runtime))?;
+                    output::writeln(&format!("Platform:    {}", info.platform))?;
+                    output::writeln(&format!("Started At:  {}", info.started_at))?;
+                    output::writeln(&format!("Uptime:      {}", info.uptime))?;
+                    output::writeln("")?;
+                    output::writeln("Configuration:")?;
+                    output::writeln(&format!("  Socket:       {}", info.config.socket))?;
+                    output::writeln(&format!("  Data Dir:     {}", info.config.data_dir))?;
+                    output::writeln(&format!("  Max Services: {}", info.config.max_services))?;
+                }
+            }
+
+            Ok(())
+        }
+    }
+}

--- a/fabricks/src/commands/mod.rs
+++ b/fabricks/src/commands/mod.rs
@@ -1,6 +1,7 @@
 //! CLI command implementations.
 
 pub mod build;
+pub mod daemon;
 pub mod inspect;
 pub mod login;
 pub mod logout;

--- a/fabricks/src/daemon_client.rs
+++ b/fabricks/src/daemon_client.rs
@@ -1,0 +1,168 @@
+//! Daemon client for communicating with fabricksd over Unix socket.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use http_body_util::{BodyExt, Empty};
+use hyper::body::Bytes;
+use hyper::Request;
+use hyper_util::rt::TokioIo;
+use serde::de::DeserializeOwned;
+use tokio::net::UnixStream;
+
+/// Client for communicating with the fabricksd daemon.
+pub struct DaemonClient {
+    socket_path: PathBuf,
+}
+
+/// API response wrapper matching the daemon's response format.
+#[derive(Debug, serde::Deserialize)]
+#[serde(tag = "status")]
+pub enum ApiResponse<T> {
+    /// Successful response.
+    #[serde(rename = "success")]
+    Success {
+        /// Response data.
+        data: T,
+    },
+
+    /// Error response.
+    #[serde(rename = "error")]
+    Error {
+        /// Error details.
+        error: ApiError,
+    },
+}
+
+/// API error details.
+#[derive(Debug, serde::Deserialize)]
+pub struct ApiError {
+    /// Error code.
+    pub code: String,
+    /// Error message.
+    pub message: String,
+}
+
+/// Daemon information response.
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct DaemonInfo {
+    /// Daemon version.
+    pub version: String,
+    /// API version.
+    pub api_version: String,
+    /// WASM runtime.
+    pub runtime: String,
+    /// Platform (os/arch).
+    pub platform: String,
+    /// When the daemon started.
+    pub started_at: String,
+    /// Human-readable uptime.
+    pub uptime: String,
+    /// Configuration info.
+    pub config: DaemonConfigInfo,
+}
+
+/// Daemon configuration subset.
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct DaemonConfigInfo {
+    /// Socket path.
+    pub socket: String,
+    /// Data directory.
+    pub data_dir: String,
+    /// Maximum services.
+    pub max_services: u32,
+}
+
+impl DaemonClient {
+    /// Creates a new daemon client.
+    ///
+    /// Uses the default socket path based on the user's home directory.
+    #[must_use]
+    pub fn new() -> Self {
+        let socket_path = default_socket_path();
+        Self { socket_path }
+    }
+
+    /// Creates a daemon client with a custom socket path.
+    #[must_use]
+    pub fn with_socket(socket_path: PathBuf) -> Self {
+        Self { socket_path }
+    }
+
+    /// Gets daemon information.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the daemon is not running or communication fails.
+    pub async fn info(&self) -> Result<DaemonInfo> {
+        self.get("/v1/daemon/info").await
+    }
+
+    /// Performs a GET request to the daemon.
+    async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
+        let stream = UnixStream::connect(&self.socket_path)
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to connect to daemon at {}. Is fabricksd running?",
+                    self.socket_path.display()
+                )
+            })?;
+
+        let io = TokioIo::new(stream);
+
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(io)
+            .await
+            .context("Failed to establish HTTP connection")?;
+
+        // Spawn connection handler
+        tokio::spawn(async move {
+            if let Err(e) = conn.await {
+                tracing::error!("Connection error: {e}");
+            }
+        });
+
+        let request = Request::builder()
+            .method("GET")
+            .uri(path)
+            .header("Host", "localhost")
+            .body(Empty::<Bytes>::new())
+            .context("Failed to build request")?;
+
+        let response = sender
+            .send_request(request)
+            .await
+            .context("Failed to send request")?;
+
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .context("Failed to read response body")?
+            .to_bytes();
+
+        let api_response: ApiResponse<T> =
+            serde_json::from_slice(&body).context("Failed to parse response")?;
+
+        match api_response {
+            ApiResponse::Success { data } => Ok(data),
+            ApiResponse::Error { error } => {
+                anyhow::bail!("{}: {}", error.code, error.message)
+            }
+        }
+    }
+}
+
+impl Default for DaemonClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Gets the default socket path.
+fn default_socket_path() -> PathBuf {
+    dirs::home_dir().map_or_else(
+        || PathBuf::from("/tmp/fabricks.sock"),
+        |h| h.join(".fabricks/fabricks.sock"),
+    )
+}

--- a/fabricks/src/main.rs
+++ b/fabricks/src/main.rs
@@ -22,6 +22,7 @@ use tokio::runtime::Runtime as TokioRuntime;
 mod cli;
 mod commands;
 mod credentials;
+mod daemon_client;
 mod output;
 
 use cli::{Cli, Commands};
@@ -53,6 +54,7 @@ fn main() -> ExitCode {
         Commands::Login(args) => commands::login::run(&args),
         Commands::Logout(args) => commands::logout::run(&args),
         Commands::Version => commands::version::run(),
+        Commands::Daemon(args) => rt.block_on(commands::daemon::run(&args)),
     };
 
     match result {

--- a/fabricks/src/output.rs
+++ b/fabricks/src/output.rs
@@ -1,9 +1,19 @@
 //! Output utilities for CLI commands.
 //!
-//! This module provides a consistent way to write output to stderr,
-//! avoiding the clippy `print_stderr` lint while maintaining testability.
+//! This module provides a consistent way to write output to stdout/stderr,
+//! avoiding the clippy `print_stdout`/`print_stderr` lints while maintaining testability.
 
 use std::io::{self, Write};
+
+/// Write a line to stdout.
+///
+/// # Errors
+///
+/// Returns an error if writing to stdout fails.
+pub fn writeln(message: &str) -> io::Result<()> {
+    let mut stdout = io::stdout();
+    writeln!(stdout, "{message}")
+}
 
 /// Write a line to stderr.
 ///

--- a/fabricksd/Cargo.toml
+++ b/fabricksd/Cargo.toml
@@ -39,6 +39,7 @@ tracing-subscriber.workspace = true
 sled.workspace = true
 uuid.workspace = true
 chrono.workspace = true
+dirs.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/fabricksd/src/api/handlers/daemon.rs
+++ b/fabricksd/src/api/handlers/daemon.rs
@@ -1,0 +1,126 @@
+//! Daemon management API handlers.
+
+use axum::{extract::State, Json};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+use crate::api::response::ApiResponse;
+use crate::state::AppState;
+
+/// Daemon information response.
+#[derive(Debug, Serialize)]
+pub struct DaemonInfo {
+    /// Daemon version.
+    pub version: String,
+
+    /// API version.
+    pub api_version: String,
+
+    /// WASM runtime name and version.
+    pub runtime: String,
+
+    /// Platform identifier (os/arch).
+    pub platform: String,
+
+    /// When the daemon started (ISO 8601).
+    pub started_at: DateTime<Utc>,
+
+    /// Human-readable uptime.
+    pub uptime: String,
+
+    /// Relevant configuration values.
+    pub config: DaemonConfigInfo,
+}
+
+/// Configuration info subset for API response.
+#[derive(Debug, Serialize)]
+pub struct DaemonConfigInfo {
+    /// Socket path.
+    pub socket: String,
+
+    /// Data directory.
+    pub data_dir: String,
+
+    /// Maximum services.
+    pub max_services: u32,
+}
+
+/// GET `/v1/daemon/info`
+///
+/// Returns information about the running daemon.
+pub async fn daemon_info(State(state): State<AppState>) -> Json<ApiResponse<DaemonInfo>> {
+    let uptime = state.uptime();
+    let uptime_str = format_uptime(uptime);
+
+    // Calculate started_at from current time minus uptime
+    let started_at = Utc::now() - chrono::Duration::from_std(uptime).unwrap_or_default();
+
+    let info = DaemonInfo {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        api_version: state.config.api.version.clone(),
+        runtime: "wasmtime".to_string(),
+        platform: format!("{}/{}", std::env::consts::OS, std::env::consts::ARCH),
+        started_at,
+        uptime: uptime_str,
+        config: DaemonConfigInfo {
+            socket: state.config.daemon.socket.display().to_string(),
+            data_dir: state.config.daemon.data_dir.display().to_string(),
+            max_services: state.config.resources.max_services,
+        },
+    };
+
+    Json(ApiResponse::success(info))
+}
+
+/// Formats a duration as a human-readable string.
+fn format_uptime(duration: std::time::Duration) -> String {
+    let total_secs = duration.as_secs();
+    let days = total_secs / 86400;
+    let hours = (total_secs % 86400) / 3600;
+    let mins = (total_secs % 3600) / 60;
+    let secs = total_secs % 60;
+
+    if days > 0 {
+        format!("{days}d {hours}h {mins}m {secs}s")
+    } else if hours > 0 {
+        format!("{hours}h {mins}m {secs}s")
+    } else if mins > 0 {
+        format!("{mins}m {secs}s")
+    } else {
+        format!("{secs}s")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_uptime_seconds() {
+        assert_eq!(format_uptime(std::time::Duration::from_secs(45)), "45s");
+    }
+
+    #[test]
+    fn test_format_uptime_minutes() {
+        assert_eq!(
+            format_uptime(std::time::Duration::from_secs(125)),
+            "2m 5s"
+        );
+    }
+
+    #[test]
+    fn test_format_uptime_hours() {
+        assert_eq!(
+            format_uptime(std::time::Duration::from_secs(3725)),
+            "1h 2m 5s"
+        );
+    }
+
+    #[test]
+    fn test_format_uptime_days() {
+        assert_eq!(
+            format_uptime(std::time::Duration::from_secs(90125)),
+            "1d 1h 2m 5s"
+        );
+    }
+}

--- a/fabricksd/src/api/handlers/mod.rs
+++ b/fabricksd/src/api/handlers/mod.rs
@@ -1,0 +1,3 @@
+//! API request handlers.
+
+pub mod daemon;

--- a/fabricksd/src/api/mod.rs
+++ b/fabricksd/src/api/mod.rs
@@ -1,0 +1,14 @@
+//! HTTP API server and handlers.
+//!
+//! This module provides the REST API for the daemon, including:
+//! - Router configuration
+//! - Response types
+//! - Request handlers
+
+mod response;
+mod router;
+
+pub mod handlers;
+
+pub use response::{ApiError, ApiResponse};
+pub use router::build_router;

--- a/fabricksd/src/api/response.rs
+++ b/fabricksd/src/api/response.rs
@@ -1,0 +1,131 @@
+//! API response types.
+
+use serde::Serialize;
+
+/// Standard API response wrapper.
+///
+/// All API responses are wrapped in this type to provide a consistent
+/// structure with status and either data or error information.
+#[derive(Debug, Serialize)]
+#[serde(tag = "status")]
+pub enum ApiResponse<T: Serialize> {
+    /// Successful response.
+    #[serde(rename = "success")]
+    Success {
+        /// Response data.
+        data: T,
+    },
+
+    /// Error response.
+    #[serde(rename = "error")]
+    Error {
+        /// Error details.
+        error: ApiError,
+    },
+}
+
+/// API error details.
+#[derive(Debug, Serialize)]
+pub struct ApiError {
+    /// Error code (e.g., `SERVICE_NOT_FOUND`).
+    pub code: String,
+
+    /// Human-readable error message.
+    pub message: String,
+
+    /// Additional error details (optional).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
+}
+
+impl<T: Serialize> ApiResponse<T> {
+    /// Creates a success response with the given data.
+    pub fn success(data: T) -> Self {
+        Self::Success { data }
+    }
+}
+
+impl ApiResponse<()> {
+    /// Creates an error response.
+    pub fn error(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::Error {
+            error: ApiError {
+                code: code.into(),
+                message: message.into(),
+                details: None,
+            },
+        }
+    }
+
+    /// Creates an error response with additional details.
+    pub fn error_with_details(
+        code: impl Into<String>,
+        message: impl Into<String>,
+        details: serde_json::Value,
+    ) -> Self {
+        Self::Error {
+            error: ApiError {
+                code: code.into(),
+                message: message.into(),
+                details: Some(details),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Serialize)]
+    struct TestData {
+        value: String,
+    }
+
+    #[test]
+    fn test_success_response_serialization() {
+        let response = ApiResponse::success(TestData {
+            value: "test".to_string(),
+        });
+
+        let json = serde_json::to_string(&response).expect("should serialize");
+        assert!(json.contains("\"status\":\"success\""));
+        assert!(json.contains("\"value\":\"test\""));
+    }
+
+    #[test]
+    fn test_error_response_serialization() {
+        let response: ApiResponse<()> =
+            ApiResponse::error("TEST_ERROR", "Something went wrong");
+
+        let json = serde_json::to_string(&response).expect("should serialize");
+        assert!(json.contains("\"status\":\"error\""));
+        assert!(json.contains("\"code\":\"TEST_ERROR\""));
+        assert!(json.contains("\"message\":\"Something went wrong\""));
+    }
+
+    #[test]
+    fn test_error_response_with_details() {
+        let response: ApiResponse<()> = ApiResponse::error_with_details(
+            "VALIDATION_ERROR",
+            "Invalid input",
+            serde_json::json!({
+                "field": "name",
+                "reason": "too short"
+            }),
+        );
+
+        let json = serde_json::to_string(&response).expect("should serialize");
+        assert!(json.contains("\"details\""));
+        assert!(json.contains("\"field\":\"name\""));
+    }
+
+    #[test]
+    fn test_error_response_without_details() {
+        let response: ApiResponse<()> = ApiResponse::error("ERROR", "message");
+
+        let json = serde_json::to_string(&response).expect("should serialize");
+        // details should be omitted entirely
+        assert!(!json.contains("\"details\""));
+    }
+}

--- a/fabricksd/src/api/router.rs
+++ b/fabricksd/src/api/router.rs
@@ -1,0 +1,118 @@
+//! Axum router configuration.
+
+use axum::{routing::get, Router};
+use tower_http::trace::TraceLayer;
+
+use super::handlers;
+use crate::state::AppState;
+
+/// Builds the complete API router.
+///
+/// This configures all API routes and applies middleware.
+pub fn build_router(state: AppState) -> Router {
+    Router::new()
+        // Daemon management
+        .route("/v1/daemon/info", get(handlers::daemon::daemon_info))
+        // Simple health check for liveness probes
+        .route("/v1/health", get(health_check))
+        // Add state
+        .with_state(state)
+        // Add tracing layer for request/response logging
+        .layer(TraceLayer::new_for_http())
+}
+
+/// Simple health check endpoint.
+///
+/// GET `/v1/health`
+///
+/// Returns "ok" if the daemon is running.
+async fn health_check() -> &'static str {
+    "ok"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tempfile::tempdir;
+    use tower::ServiceExt;
+
+    use crate::config::DaemonConfig;
+
+    fn create_test_state() -> AppState {
+        let dir = tempdir().expect("should create temp dir");
+        let mut config = DaemonConfig::default();
+        config.daemon.data_dir = dir.keep();
+        AppState::new(config).expect("should create state")
+    }
+
+    #[tokio::test]
+    async fn test_health_check_endpoint() {
+        let state = create_test_state();
+        let app = build_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/health")
+                    .body(Body::empty())
+                    .expect("should build request"),
+            )
+            .await
+            .expect("should get response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_daemon_info_endpoint() {
+        let state = create_test_state();
+        let app = build_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/daemon/info")
+                    .body(Body::empty())
+                    .expect("should build request"),
+            )
+            .await
+            .expect("should get response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("should read body");
+        let json: serde_json::Value =
+            serde_json::from_slice(&body).expect("should parse json");
+
+        assert_eq!(json["status"], "success");
+        assert!(json["data"]["version"].is_string());
+        assert!(json["data"]["api_version"].is_string());
+        assert!(json["data"]["runtime"].is_string());
+        assert!(json["data"]["platform"].is_string());
+        assert!(json["data"]["uptime"].is_string());
+    }
+
+    #[tokio::test]
+    async fn test_not_found() {
+        let state = create_test_state();
+        let app = build_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/nonexistent")
+                    .body(Body::empty())
+                    .expect("should build request"),
+            )
+            .await
+            .expect("should get response");
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/fabricksd/src/config.rs
+++ b/fabricksd/src/config.rs
@@ -1,0 +1,386 @@
+//! Daemon configuration types and loading logic.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use fabricks_common::models::common::Duration;
+
+use crate::error::{DaemonError, Result};
+
+/// System-wide configuration file path.
+const SYSTEM_CONFIG_PATH: &str = "/etc/fabricksd/config.toml";
+
+/// User configuration file name within home directory.
+const USER_CONFIG_FILE: &str = ".fabricks/daemon.toml";
+
+/// Daemon configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DaemonConfig {
+    /// Daemon-level settings.
+    #[serde(default)]
+    pub daemon: DaemonSettings,
+
+    /// API settings.
+    #[serde(default)]
+    pub api: ApiSettings,
+
+    /// Runtime settings.
+    #[serde(default)]
+    pub runtime: RuntimeSettings,
+
+    /// Resource limits.
+    #[serde(default)]
+    pub resources: ResourceSettings,
+
+    /// Monitoring settings.
+    #[serde(default)]
+    pub monitoring: MonitoringSettings,
+
+    /// Event bus settings.
+    #[serde(default)]
+    pub events: EventSettings,
+}
+
+/// Core daemon settings.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaemonSettings {
+    /// Unix socket path.
+    #[serde(default = "default_socket_path")]
+    pub socket: PathBuf,
+
+    /// PID file path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pid_file: Option<PathBuf>,
+
+    /// Log level: trace, debug, info, warn, error.
+    #[serde(default = "default_log_level")]
+    pub log_level: String,
+
+    /// Data directory for state and cache.
+    #[serde(default = "default_data_dir")]
+    pub data_dir: PathBuf,
+}
+
+/// API-specific settings.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiSettings {
+    /// API version prefix.
+    #[serde(default = "default_api_version")]
+    pub version: String,
+
+    /// Whether authentication is required.
+    #[serde(default)]
+    pub auth_enabled: bool,
+
+    /// API key (if `auth_enabled` is true).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
+
+    /// Request timeout.
+    #[serde(default = "default_request_timeout")]
+    pub timeout: Duration,
+}
+
+/// WASM runtime settings.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeSettings {
+    /// Default WASM engine (wasmtime).
+    #[serde(default = "default_engine")]
+    pub default_engine: String,
+
+    /// Maximum number of cached modules.
+    #[serde(default = "default_max_modules")]
+    pub max_cached_modules: usize,
+}
+
+/// Global resource limits.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResourceSettings {
+    /// Maximum total services.
+    #[serde(default = "default_max_services")]
+    pub max_services: u32,
+
+    /// Maximum replicas per service.
+    #[serde(default = "default_max_replicas")]
+    pub max_replicas_per_service: u32,
+}
+
+/// Monitoring and health check settings.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MonitoringSettings {
+    /// Default health check interval.
+    #[serde(default = "default_health_interval")]
+    pub health_check_interval: Duration,
+
+    /// Default health check timeout.
+    #[serde(default = "default_health_timeout")]
+    pub health_check_timeout: Duration,
+}
+
+/// Event bus settings.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventSettings {
+    /// Event channel buffer size.
+    #[serde(default = "default_buffer_size")]
+    pub buffer_size: usize,
+
+    /// Maximum event history to retain.
+    #[serde(default = "default_history_size")]
+    pub history_size: usize,
+}
+
+// Default value functions
+
+fn default_socket_path() -> PathBuf {
+    // Use user-level socket path by default.
+    // System-wide deployments should use config file to override.
+    dirs::home_dir().map_or_else(
+        || PathBuf::from("/tmp/fabricks.sock"),
+        |h| h.join(".fabricks/fabricks.sock"),
+    )
+}
+
+fn default_log_level() -> String {
+    "info".to_string()
+}
+
+fn default_data_dir() -> PathBuf {
+    // Use user-level data directory by default.
+    // System-wide deployments should use config file to override.
+    dirs::data_local_dir().map_or_else(
+        || {
+            dirs::home_dir().map_or_else(
+                || PathBuf::from("/tmp/fabricks"),
+                |h| h.join(".local/share/fabricks"),
+            )
+        },
+        |d| d.join("fabricks"),
+    )
+}
+
+fn default_api_version() -> String {
+    "v1".to_string()
+}
+
+fn default_request_timeout() -> Duration {
+    Duration::from_secs(30)
+}
+
+fn default_engine() -> String {
+    "wasmtime".to_string()
+}
+
+fn default_max_modules() -> usize {
+    100
+}
+
+fn default_max_services() -> u32 {
+    100
+}
+
+fn default_max_replicas() -> u32 {
+    20
+}
+
+fn default_health_interval() -> Duration {
+    Duration::from_secs(5)
+}
+
+fn default_health_timeout() -> Duration {
+    Duration::from_secs(3)
+}
+
+fn default_buffer_size() -> usize {
+    1000
+}
+
+fn default_history_size() -> usize {
+    10000
+}
+
+// Default trait implementations
+
+impl Default for DaemonSettings {
+    fn default() -> Self {
+        Self {
+            socket: default_socket_path(),
+            pid_file: None,
+            log_level: default_log_level(),
+            data_dir: default_data_dir(),
+        }
+    }
+}
+
+impl Default for ApiSettings {
+    fn default() -> Self {
+        Self {
+            version: default_api_version(),
+            auth_enabled: false,
+            api_key: None,
+            timeout: default_request_timeout(),
+        }
+    }
+}
+
+impl Default for RuntimeSettings {
+    fn default() -> Self {
+        Self {
+            default_engine: default_engine(),
+            max_cached_modules: default_max_modules(),
+        }
+    }
+}
+
+impl Default for ResourceSettings {
+    fn default() -> Self {
+        Self {
+            max_services: default_max_services(),
+            max_replicas_per_service: default_max_replicas(),
+        }
+    }
+}
+
+impl Default for MonitoringSettings {
+    fn default() -> Self {
+        Self {
+            health_check_interval: default_health_interval(),
+            health_check_timeout: default_health_timeout(),
+        }
+    }
+}
+
+impl Default for EventSettings {
+    fn default() -> Self {
+        Self {
+            buffer_size: default_buffer_size(),
+            history_size: default_history_size(),
+        }
+    }
+}
+
+
+impl DaemonConfig {
+    /// Load configuration from file or use defaults.
+    ///
+    /// Searches for configuration files in the following order:
+    /// 1. System-wide: `/etc/fabricksd/config.toml`
+    /// 2. User-specific: `~/.fabricks/daemon.toml`
+    /// 3. Falls back to defaults if no file found
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a configuration file exists but cannot be read or parsed.
+    pub fn load() -> Result<Self> {
+        // Try system config first
+        let system_path = Path::new(SYSTEM_CONFIG_PATH);
+        if system_path.exists() {
+            return Self::load_from(system_path);
+        }
+
+        // Try user config
+        if let Some(home) = dirs::home_dir() {
+            let user_path = home.join(USER_CONFIG_FILE);
+            if user_path.exists() {
+                return Self::load_from(&user_path);
+            }
+        }
+
+        // Fall back to defaults
+        Ok(Self::default())
+    }
+
+    /// Load configuration from a specific path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be read or parsed as valid TOML.
+    pub fn load_from<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let path = path.as_ref();
+        let content = fs::read_to_string(path).map_err(|e| DaemonError::ConfigLoadError {
+            path: path.to_path_buf(),
+            reason: e.to_string(),
+        })?;
+
+        let config: Self = toml::from_str(&content)?;
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = DaemonConfig::default();
+        assert_eq!(config.api.version, "v1");
+        assert!(!config.api.auth_enabled);
+        assert_eq!(config.resources.max_services, 100);
+        assert_eq!(config.events.buffer_size, 1000);
+    }
+
+    #[test]
+    fn test_parse_minimal_config() {
+        let toml = r#"
+            [daemon]
+            log_level = "debug"
+        "#;
+
+        let config: DaemonConfig = toml::from_str(toml).expect("should parse");
+        assert_eq!(config.daemon.log_level, "debug");
+        // Other fields should use defaults
+        assert_eq!(config.api.version, "v1");
+    }
+
+    #[test]
+    fn test_parse_full_config() {
+        let toml = r#"
+            [daemon]
+            socket = "/tmp/test.sock"
+            log_level = "trace"
+            data_dir = "/tmp/fabricks-data"
+
+            [api]
+            version = "v2"
+            auth_enabled = true
+            api_key = "secret"
+            timeout = "60s"
+
+            [runtime]
+            default_engine = "wasmtime"
+            max_cached_modules = 50
+
+            [resources]
+            max_services = 200
+            max_replicas_per_service = 50
+
+            [monitoring]
+            health_check_interval = "10s"
+            health_check_timeout = "5s"
+
+            [events]
+            buffer_size = 2000
+            history_size = 20000
+        "#;
+
+        let config: DaemonConfig = toml::from_str(toml).expect("should parse");
+        assert_eq!(config.daemon.socket, PathBuf::from("/tmp/test.sock"));
+        assert_eq!(config.daemon.log_level, "trace");
+        assert_eq!(config.api.version, "v2");
+        assert!(config.api.auth_enabled);
+        assert_eq!(config.api.api_key.as_deref(), Some("secret"));
+        assert_eq!(config.api.timeout.as_secs(), 60);
+        assert_eq!(config.resources.max_services, 200);
+        assert_eq!(config.events.buffer_size, 2000);
+    }
+
+    #[test]
+    fn test_load_nonexistent_defaults_to_default() {
+        // Loading from a path that doesn't exist should work via load()
+        // since it falls back to defaults
+        let config = DaemonConfig::load().expect("should fall back to defaults");
+        assert_eq!(config.api.version, "v1");
+    }
+}

--- a/fabricksd/src/error.rs
+++ b/fabricksd/src/error.rs
@@ -1,0 +1,85 @@
+//! Error types for the Fabricks daemon.
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+/// Errors that can occur during daemon operations.
+#[derive(Debug, Error)]
+pub enum DaemonError {
+    /// Failed to load configuration file.
+    #[error("failed to load configuration from '{path}': {reason}")]
+    ConfigLoadError {
+        /// Configuration file path.
+        path: PathBuf,
+        /// Reason for the failure.
+        reason: String,
+    },
+
+    /// Failed to parse configuration.
+    #[error("invalid configuration: {0}")]
+    ConfigParseError(#[from] toml::de::Error),
+
+    /// Failed to create or bind Unix socket.
+    #[error("failed to bind Unix socket at '{path}': {source}")]
+    SocketBindError {
+        /// Socket path.
+        path: PathBuf,
+        /// Underlying IO error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// Failed to open or access database.
+    #[error("database error: {0}")]
+    DatabaseError(#[from] sled::Error),
+
+    /// JSON serialization/deserialization error.
+    #[error("serialization error: {0}")]
+    SerializationError(#[from] serde_json::Error),
+
+    /// IO error.
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    /// Service not found.
+    #[error("service not found: {id}")]
+    ServiceNotFound {
+        /// Service ID.
+        id: String,
+    },
+
+    /// Network not found.
+    #[error("network not found: {id}")]
+    NetworkNotFound {
+        /// Network ID.
+        id: String,
+    },
+
+    /// Volume not found.
+    #[error("volume not found: {id}")]
+    VolumeNotFound {
+        /// Volume ID.
+        id: String,
+    },
+
+    /// Invalid state transition.
+    #[error("invalid state transition from '{from}' to '{to}'")]
+    InvalidStateTransition {
+        /// Current state.
+        from: String,
+        /// Requested state.
+        to: String,
+    },
+
+    /// Shutdown in progress.
+    #[error("daemon is shutting down")]
+    ShuttingDown,
+
+    /// Event bus send error.
+    #[error("failed to publish event: channel closed")]
+    EventBusClosed,
+}
+
+/// Result type for daemon operations.
+pub type Result<T> = std::result::Result<T, DaemonError>;

--- a/fabricksd/src/events/bus.rs
+++ b/fabricksd/src/events/bus.rs
@@ -1,0 +1,272 @@
+//! Event bus for pub/sub messaging.
+
+use std::collections::VecDeque;
+
+use tokio::sync::{mpsc, RwLock};
+
+use super::types::{Event, EventType};
+
+/// Event bus for publishing and subscribing to daemon events.
+///
+/// The event bus provides a simple pub/sub mechanism for daemon events.
+/// Subscribers receive events through async channels, and the bus maintains
+/// a ring buffer of recent events for history queries.
+pub struct EventBus {
+    /// Active subscribers.
+    subscribers: RwLock<Vec<mpsc::Sender<Event>>>,
+
+    /// Event history (ring buffer).
+    history: RwLock<VecDeque<Event>>,
+
+    /// Maximum history size.
+    max_history: usize,
+
+    /// Channel buffer size for new subscribers.
+    buffer_size: usize,
+}
+
+impl EventBus {
+    /// Creates a new event bus.
+    ///
+    /// # Arguments
+    ///
+    /// * `buffer_size` - The buffer size for subscriber channels
+    /// * `max_history` - The maximum number of events to retain in history
+    #[must_use]
+    pub fn new(buffer_size: usize, max_history: usize) -> Self {
+        Self {
+            subscribers: RwLock::new(Vec::new()),
+            history: RwLock::new(VecDeque::with_capacity(max_history)),
+            max_history,
+            buffer_size,
+        }
+    }
+
+    /// Publishes an event to all subscribers.
+    ///
+    /// The event is added to the history and sent to all active subscribers.
+    /// Subscribers with full or closed channels are automatically removed.
+    pub async fn publish(&self, event: Event) {
+        // Add to history
+        {
+            let mut history = self.history.write().await;
+            if history.len() >= self.max_history {
+                history.pop_front();
+            }
+            history.push_back(event.clone());
+        }
+
+        // Send to all subscribers, remove closed channels
+        let mut subscribers = self.subscribers.write().await;
+        subscribers.retain(|tx| tx.try_send(event.clone()).is_ok());
+    }
+
+    /// Subscribes to all events.
+    ///
+    /// Returns a receiver channel that will receive all published events.
+    pub async fn subscribe(&self) -> mpsc::Receiver<Event> {
+        let (tx, rx) = mpsc::channel(self.buffer_size);
+        self.subscribers.write().await.push(tx);
+        rx
+    }
+
+    /// Subscribes to events matching the given filter.
+    ///
+    /// Returns a receiver channel that will only receive events of the
+    /// specified types.
+    ///
+    /// # Arguments
+    ///
+    /// * `filter` - The event types to subscribe to
+    pub async fn subscribe_filtered(&self, filter: Vec<EventType>) -> mpsc::Receiver<Event> {
+        let (outer_tx, outer_rx) = mpsc::channel(self.buffer_size);
+        let mut inner_rx = self.subscribe().await;
+
+        tokio::spawn(async move {
+            while let Some(event) = inner_rx.recv().await {
+                let should_send = filter.contains(&event.event_type);
+                if should_send && outer_tx.send(event).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        outer_rx
+    }
+
+    /// Gets event history.
+    ///
+    /// Returns events in reverse chronological order (newest first).
+    ///
+    /// # Arguments
+    ///
+    /// * `limit` - Optional limit on the number of events to return
+    pub async fn history(&self, limit: Option<usize>) -> Vec<Event> {
+        let history = self.history.read().await;
+        let iter = history.iter().rev();
+        match limit {
+            Some(n) => iter.take(n).cloned().collect(),
+            None => iter.cloned().collect(),
+        }
+    }
+
+    /// Gets the number of active subscribers.
+    pub async fn subscriber_count(&self) -> usize {
+        self.subscribers.read().await.len()
+    }
+
+    /// Clears all event history.
+    pub async fn clear_history(&self) {
+        self.history.write().await.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn test_publish_and_subscribe() {
+        let bus = EventBus::new(10, 100);
+
+        let mut rx = bus.subscribe().await;
+        assert_eq!(bus.subscriber_count().await, 1);
+
+        let event = Event::new(EventType::DaemonStarted, serde_json::json!({
+            "version": "1.0.0"
+        }));
+
+        bus.publish(event.clone()).await;
+
+        let received = tokio::time::timeout(Duration::from_millis(100), rx.recv())
+            .await
+            .expect("should not timeout")
+            .expect("should receive event");
+
+        assert_eq!(received.id, event.id);
+        assert_eq!(received.event_type, EventType::DaemonStarted);
+    }
+
+    #[tokio::test]
+    async fn test_multiple_subscribers() {
+        let bus = EventBus::new(10, 100);
+
+        let mut rx1 = bus.subscribe().await;
+        let mut rx2 = bus.subscribe().await;
+        assert_eq!(bus.subscriber_count().await, 2);
+
+        let event = Event::empty(EventType::ServiceCreated);
+        bus.publish(event.clone()).await;
+
+        let received1 = rx1.recv().await.expect("should receive");
+        let received2 = rx2.recv().await.expect("should receive");
+
+        assert_eq!(received1.id, event.id);
+        assert_eq!(received2.id, event.id);
+    }
+
+    #[tokio::test]
+    async fn test_filtered_subscription() {
+        let bus = EventBus::new(10, 100);
+
+        let mut rx = bus
+            .subscribe_filtered(vec![EventType::ServiceStarted, EventType::ServiceStopped])
+            .await;
+
+        // Should not receive this
+        bus.publish(Event::empty(EventType::DaemonStarted)).await;
+        // Should receive this
+        bus.publish(Event::empty(EventType::ServiceStarted)).await;
+        // Should not receive this
+        bus.publish(Event::empty(EventType::NetworkCreated)).await;
+        // Should receive this
+        bus.publish(Event::empty(EventType::ServiceStopped)).await;
+
+        let received1 = tokio::time::timeout(Duration::from_millis(100), rx.recv())
+            .await
+            .expect("should not timeout")
+            .expect("should receive");
+        assert_eq!(received1.event_type, EventType::ServiceStarted);
+
+        let received2 = tokio::time::timeout(Duration::from_millis(100), rx.recv())
+            .await
+            .expect("should not timeout")
+            .expect("should receive");
+        assert_eq!(received2.event_type, EventType::ServiceStopped);
+    }
+
+    #[tokio::test]
+    async fn test_history() {
+        let bus = EventBus::new(10, 100);
+
+        bus.publish(Event::empty(EventType::ServiceCreated)).await;
+        bus.publish(Event::empty(EventType::ServiceStarted)).await;
+        bus.publish(Event::empty(EventType::ServiceStopped)).await;
+
+        let history = bus.history(None).await;
+        assert_eq!(history.len(), 3);
+        // Newest first
+        assert_eq!(history[0].event_type, EventType::ServiceStopped);
+        assert_eq!(history[1].event_type, EventType::ServiceStarted);
+        assert_eq!(history[2].event_type, EventType::ServiceCreated);
+    }
+
+    #[tokio::test]
+    async fn test_history_limit() {
+        let bus = EventBus::new(10, 100);
+
+        for _ in 0..10 {
+            bus.publish(Event::empty(EventType::ServiceCreated)).await;
+        }
+
+        let history = bus.history(Some(5)).await;
+        assert_eq!(history.len(), 5);
+    }
+
+    #[tokio::test]
+    async fn test_history_ring_buffer() {
+        let bus = EventBus::new(10, 5); // max 5 events
+
+        for i in 0..10 {
+            bus.publish(Event::new(EventType::ServiceCreated, serde_json::json!({
+                "index": i
+            })))
+            .await;
+        }
+
+        let history = bus.history(None).await;
+        assert_eq!(history.len(), 5);
+        // Should only have events 5-9 (newest)
+        assert_eq!(history[0].data["index"], 9);
+        assert_eq!(history[4].data["index"], 5);
+    }
+
+    #[tokio::test]
+    async fn test_subscriber_cleanup_on_channel_close() {
+        let bus = EventBus::new(10, 100);
+
+        let rx = bus.subscribe().await;
+        assert_eq!(bus.subscriber_count().await, 1);
+
+        // Drop the receiver
+        drop(rx);
+
+        // Publish an event - this should clean up the dead subscriber
+        bus.publish(Event::empty(EventType::DaemonStarted)).await;
+
+        assert_eq!(bus.subscriber_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_clear_history() {
+        let bus = EventBus::new(10, 100);
+
+        bus.publish(Event::empty(EventType::ServiceCreated)).await;
+        bus.publish(Event::empty(EventType::ServiceStarted)).await;
+        assert_eq!(bus.history(None).await.len(), 2);
+
+        bus.clear_history().await;
+        assert_eq!(bus.history(None).await.len(), 0);
+    }
+}

--- a/fabricksd/src/events/mod.rs
+++ b/fabricksd/src/events/mod.rs
@@ -1,0 +1,10 @@
+//! Event system for pub/sub messaging.
+//!
+//! This module provides the [`EventBus`] for publishing and subscribing
+//! to daemon events, as well as event type definitions.
+
+mod bus;
+mod types;
+
+pub use bus::EventBus;
+pub use types::{Event, EventType};

--- a/fabricksd/src/events/types.rs
+++ b/fabricksd/src/events/types.rs
@@ -1,0 +1,137 @@
+//! Event type definitions.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Event categories for daemon operations.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum EventType {
+    // Daemon lifecycle events
+    /// Daemon has started.
+    DaemonStarted,
+    /// Daemon is stopping.
+    DaemonStopping,
+    /// Daemon configuration was reloaded.
+    DaemonConfigReloaded,
+
+    // Service lifecycle events
+    /// A service was created.
+    ServiceCreated,
+    /// A service was started.
+    ServiceStarted,
+    /// A service was stopped.
+    ServiceStopped,
+    /// A service failed.
+    ServiceFailed,
+    /// A service was scaled.
+    ServiceScaled,
+    /// A service was deleted.
+    ServiceDeleted,
+
+    // Health events
+    /// Service health status changed.
+    HealthChanged,
+
+    // Network events
+    /// A network was created.
+    NetworkCreated,
+    /// A network was deleted.
+    NetworkDeleted,
+
+    // Volume events
+    /// A volume was created.
+    VolumeCreated,
+    /// A volume was deleted.
+    VolumeDeleted,
+}
+
+/// A daemon event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Event {
+    /// Unique event ID.
+    pub id: Uuid,
+
+    /// Event type.
+    pub event_type: EventType,
+
+    /// When the event occurred.
+    pub timestamp: DateTime<Utc>,
+
+    /// Event-specific data.
+    pub data: serde_json::Value,
+}
+
+impl Event {
+    /// Creates a new event with the given type and data.
+    ///
+    /// The event ID and timestamp are automatically generated.
+    pub fn new<T: Serialize>(event_type: EventType, data: T) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            event_type,
+            timestamp: Utc::now(),
+            data: serde_json::to_value(data).unwrap_or(serde_json::Value::Null),
+        }
+    }
+
+    /// Creates a new event with no data.
+    #[must_use]
+    pub fn empty(event_type: EventType) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            event_type,
+            timestamp: Utc::now(),
+            data: serde_json::Value::Null,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_event_creation() {
+        let event = Event::new(EventType::DaemonStarted, serde_json::json!({
+            "version": "1.0.0"
+        }));
+
+        assert_eq!(event.event_type, EventType::DaemonStarted);
+        assert!(!event.id.is_nil());
+        assert_eq!(event.data["version"], "1.0.0");
+    }
+
+    #[test]
+    fn test_event_empty() {
+        let event = Event::empty(EventType::DaemonStopping);
+
+        assert_eq!(event.event_type, EventType::DaemonStopping);
+        assert!(event.data.is_null());
+    }
+
+    #[test]
+    fn test_event_serialization() {
+        let event = Event::new(EventType::ServiceCreated, serde_json::json!({
+            "service_id": "test-service"
+        }));
+
+        let json = serde_json::to_string(&event).expect("should serialize");
+        let parsed: Event = serde_json::from_str(&json).expect("should parse");
+
+        assert_eq!(parsed.id, event.id);
+        assert_eq!(parsed.event_type, event.event_type);
+        assert_eq!(parsed.data["service_id"], "test-service");
+    }
+
+    #[test]
+    fn test_event_type_serialization() {
+        let event_type = EventType::ServiceStarted;
+        let json = serde_json::to_string(&event_type).expect("should serialize");
+        assert_eq!(json, "\"service_started\"");
+
+        let parsed: EventType = serde_json::from_str(&json).expect("should parse");
+        assert_eq!(parsed, EventType::ServiceStarted);
+    }
+}

--- a/fabricksd/src/lib.rs
+++ b/fabricksd/src/lib.rs
@@ -1,0 +1,29 @@
+//! Fabricks Daemon Library
+//!
+//! This crate provides the core functionality for the Fabricks daemon,
+//! including the HTTP API server, state persistence, and event system.
+//!
+//! # Modules
+//!
+//! - [`error`] - Error types for daemon operations
+//! - [`config`] - Configuration loading and management
+//! - [`state`] - Application state container
+//! - [`store`] - Persistent state storage using sled
+//! - [`events`] - Event bus for pub/sub messaging
+//! - [`api`] - HTTP API server and handlers
+//! - [`shutdown`] - Graceful shutdown coordination
+
+pub mod api;
+pub mod config;
+pub mod error;
+pub mod events;
+pub mod shutdown;
+pub mod state;
+pub mod store;
+
+// Re-export commonly used types at crate root for convenience.
+pub use config::DaemonConfig;
+pub use error::{DaemonError, Result};
+pub use events::{Event, EventBus, EventType};
+pub use state::AppState;
+pub use store::StateStore;

--- a/fabricksd/src/main.rs
+++ b/fabricksd/src/main.rs
@@ -11,9 +11,104 @@
 //!
 //! # API
 //!
-//! The daemon exposes a REST API at `/v1/*` via Unix socket
-//! at `/var/run/fabricks.sock`.
+//! The daemon exposes a REST API at `/v1/*` via Unix socket.
+//! Default socket path is `~/.fabricks/fabricks.sock` for user mode
+//! or `/var/run/fabricks.sock` for system mode.
+//!
+//! # Configuration
+//!
+//! Configuration is loaded from:
+//! 1. `/etc/fabricksd/config.toml` (system-wide)
+//! 2. `~/.fabricks/daemon.toml` (user-specific)
+//! 3. Falls back to defaults if no config file found
 
-fn main() {
-    // Daemon implementation will be added in Phase 6
+use std::time::Duration;
+
+use tokio::net::UnixListener;
+use tracing::{error, info};
+use tracing_subscriber::EnvFilter;
+
+use fabricksd::api::build_router;
+use fabricksd::config::DaemonConfig;
+use fabricksd::events::{Event, EventType};
+use fabricksd::shutdown::shutdown_signal;
+use fabricksd::state::AppState;
+
+/// Shutdown timeout in seconds.
+const SHUTDOWN_TIMEOUT_SECS: u64 = 30;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Initialize tracing
+    init_tracing();
+
+    info!("Starting fabricksd v{}", env!("CARGO_PKG_VERSION"));
+
+    // Load configuration
+    let config = DaemonConfig::load()?;
+    info!(
+        socket = %config.daemon.socket.display(),
+        data_dir = %config.daemon.data_dir.display(),
+        "Loaded configuration"
+    );
+
+    // Create application state
+    let state = AppState::new(config.clone())?;
+    info!("Initialized state");
+
+    // Publish startup event
+    let startup_event = Event::new(
+        EventType::DaemonStarted,
+        serde_json::json!({
+            "version": env!("CARGO_PKG_VERSION"),
+            "socket": config.daemon.socket.display().to_string(),
+        }),
+    );
+    state.event_bus.publish(startup_event).await;
+
+    // Remove existing socket file if present
+    if config.daemon.socket.exists() {
+        std::fs::remove_file(&config.daemon.socket)?;
+        info!("Removed existing socket file");
+    }
+
+    // Ensure parent directory exists
+    if let Some(parent) = config.daemon.socket.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    // Create Unix socket listener
+    let listener = UnixListener::bind(&config.daemon.socket).map_err(|e| {
+        error!(path = %config.daemon.socket.display(), error = %e, "Failed to bind socket");
+        fabricksd::DaemonError::SocketBindError {
+            path: config.daemon.socket.clone(),
+            source: e,
+        }
+    })?;
+    info!(socket = %config.daemon.socket.display(), "Listening on Unix socket");
+
+    // Build router
+    let app = build_router(state.clone());
+
+    // Run server with graceful shutdown
+    let shutdown_timeout = Duration::from_secs(SHUTDOWN_TIMEOUT_SECS);
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal(state, shutdown_timeout))
+        .await?;
+
+    info!("Daemon stopped");
+    Ok(())
+}
+
+/// Initializes tracing with environment-based filtering.
+fn init_tracing() {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_target(true)
+        .with_thread_ids(false)
+        .with_file(false)
+        .with_line_number(false)
+        .init();
 }

--- a/fabricksd/src/shutdown.rs
+++ b/fabricksd/src/shutdown.rs
@@ -1,0 +1,64 @@
+//! Graceful shutdown handling.
+
+use std::time::Duration;
+
+use tokio::signal;
+use tracing::{error, info};
+
+use crate::events::{Event, EventType};
+use crate::state::AppState;
+
+/// Waits for shutdown signal and coordinates graceful shutdown.
+///
+/// This function listens for SIGTERM and SIGINT signals, publishes a
+/// shutdown event, and signals all tasks to clean up before returning.
+///
+/// # Arguments
+///
+/// * `state` - The application state
+/// * `timeout` - Maximum time to wait for cleanup before returning
+pub async fn shutdown_signal(state: AppState, timeout: Duration) {
+    let ctrl_c = async {
+        if let Err(e) = signal::ctrl_c().await {
+            error!("Failed to install Ctrl+C handler: {e}");
+        }
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        match signal::unix::signal(signal::unix::SignalKind::terminate()) {
+            Ok(mut signal) => {
+                signal.recv().await;
+            }
+            Err(e) => {
+                error!("Failed to install SIGTERM handler: {e}");
+            }
+        }
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c => info!("Received Ctrl+C, initiating shutdown"),
+        () = terminate => info!("Received SIGTERM, initiating shutdown"),
+    }
+
+    // Publish shutdown event
+    let event = Event::new(
+        EventType::DaemonStopping,
+        serde_json::json!({
+            "reason": "signal"
+        }),
+    );
+    state.event_bus.publish(event).await;
+
+    // Signal all tasks to shut down
+    state.shutdown();
+
+    // Give tasks time to clean up
+    info!("Waiting for tasks to complete (timeout: {timeout:?})");
+    tokio::time::sleep(timeout).await;
+
+    info!("Shutdown complete");
+}

--- a/fabricksd/src/state.rs
+++ b/fabricksd/src/state.rs
@@ -1,0 +1,151 @@
+//! Shared application state for the daemon.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use sled::Db;
+use tokio::sync::broadcast;
+
+use crate::config::DaemonConfig;
+use crate::error::Result;
+use crate::events::EventBus;
+use crate::store::StateStore;
+
+/// Shared daemon state accessible from all handlers.
+///
+/// This struct is cheaply cloneable (all fields are `Arc`-wrapped) and
+/// is passed to all API handlers via axum's state extraction.
+#[derive(Clone)]
+pub struct AppState {
+    /// Daemon configuration.
+    pub config: Arc<DaemonConfig>,
+
+    /// Time when daemon started.
+    started_at: Instant,
+
+    /// Embedded database.
+    pub db: Arc<Db>,
+
+    /// Persistent state store.
+    pub store: Arc<StateStore>,
+
+    /// Event bus for publishing events.
+    pub event_bus: Arc<EventBus>,
+
+    /// Shutdown signal sender.
+    shutdown_tx: broadcast::Sender<()>,
+}
+
+impl AppState {
+    /// Creates a new application state.
+    ///
+    /// This initializes the database, state store, and event bus.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the data directory cannot be created or the
+    /// database cannot be opened.
+    pub fn new(config: DaemonConfig) -> Result<Self> {
+        // Ensure data directory exists
+        std::fs::create_dir_all(&config.daemon.data_dir)?;
+
+        // Open sled database
+        let db_path = config.daemon.data_dir.join("state.db");
+        let db = sled::open(&db_path)?;
+        let db = Arc::new(db);
+
+        // Create state store
+        let store = Arc::new(StateStore::new(Arc::clone(&db)));
+
+        // Create event bus
+        let event_bus = Arc::new(EventBus::new(
+            config.events.buffer_size,
+            config.events.history_size,
+        ));
+
+        // Create shutdown channel
+        let (shutdown_tx, _) = broadcast::channel(1);
+
+        Ok(Self {
+            config: Arc::new(config),
+            started_at: Instant::now(),
+            db,
+            store,
+            event_bus,
+            shutdown_tx,
+        })
+    }
+
+    /// Gets the daemon uptime.
+    #[must_use]
+    pub fn uptime(&self) -> std::time::Duration {
+        self.started_at.elapsed()
+    }
+
+    /// Sends shutdown signal to all listeners.
+    ///
+    /// This notifies all tasks that have subscribed to the shutdown signal
+    /// to begin their cleanup procedures.
+    pub fn shutdown(&self) {
+        // Ignore send errors - receivers may have already been dropped
+        let _ = self.shutdown_tx.send(());
+    }
+
+    /// Subscribes to the shutdown signal.
+    ///
+    /// Returns a receiver that will receive a message when the daemon
+    /// is shutting down.
+    #[must_use]
+    pub fn subscribe_shutdown(&self) -> broadcast::Receiver<()> {
+        self.shutdown_tx.subscribe()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tempfile::tempdir;
+
+    fn create_test_config() -> DaemonConfig {
+        let dir = tempdir().expect("should create temp dir");
+        let mut config = DaemonConfig::default();
+        config.daemon.data_dir = dir.keep();
+        config
+    }
+
+    #[test]
+    fn test_app_state_creation() {
+        let config = create_test_config();
+        let state = AppState::new(config).expect("should create state");
+
+        assert!(state.uptime() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn test_app_state_clone() {
+        let config = create_test_config();
+        let state = AppState::new(config).expect("should create state");
+
+        let cloned = state.clone();
+        assert!(Arc::ptr_eq(&state.config, &cloned.config));
+        assert!(Arc::ptr_eq(&state.db, &cloned.db));
+        assert!(Arc::ptr_eq(&state.store, &cloned.store));
+        assert!(Arc::ptr_eq(&state.event_bus, &cloned.event_bus));
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_signal() {
+        let config = create_test_config();
+        let state = AppState::new(config).expect("should create state");
+
+        let mut rx = state.subscribe_shutdown();
+
+        // Shutdown should succeed
+        state.shutdown();
+
+        // Receiver should get the signal
+        let result = tokio::time::timeout(Duration::from_millis(100), rx.recv()).await;
+        assert!(result.is_ok());
+    }
+}

--- a/fabricksd/src/store/mod.rs
+++ b/fabricksd/src/store/mod.rs
@@ -1,0 +1,8 @@
+//! Persistent state storage module.
+//!
+//! This module provides the [`StateStore`] for persisting daemon state
+//! to a sled embedded database.
+
+mod state_store;
+
+pub use state_store::StateStore;

--- a/fabricksd/src/store/state_store.rs
+++ b/fabricksd/src/store/state_store.rs
@@ -1,0 +1,316 @@
+//! Persistent state storage using sled.
+
+use std::sync::Arc;
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use sled::Db;
+
+use crate::error::Result;
+
+/// Well-known tree names for different entity types.
+///
+/// These constants are used in later phases for organizing data in the store.
+#[allow(dead_code)]
+pub mod trees {
+    /// Tree for service state.
+    pub const SERVICES: &str = "services";
+    /// Tree for network state.
+    pub const NETWORKS: &str = "networks";
+    /// Tree for volume state.
+    pub const VOLUMES: &str = "volumes";
+    /// Tree for daemon metadata.
+    pub const METADATA: &str = "metadata";
+}
+
+/// Persistent state store backed by sled.
+///
+/// Provides a generic key-value interface for storing serializable data
+/// organized into separate trees (namespaces).
+#[derive(Clone)]
+pub struct StateStore {
+    db: Arc<Db>,
+}
+
+impl StateStore {
+    /// Creates a new state store wrapping the given database.
+    #[must_use]
+    pub fn new(db: Arc<Db>) -> Self {
+        Self { db }
+    }
+
+    /// Stores a serializable value in the specified tree.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if serialization fails or the database operation fails.
+    pub fn put<T: Serialize>(&self, tree_name: &str, key: &str, value: &T) -> Result<()> {
+        let tree = self.db.open_tree(tree_name)?;
+        let json = serde_json::to_vec(value)?;
+        tree.insert(key.as_bytes(), json)?;
+        tree.flush()?;
+        Ok(())
+    }
+
+    /// Retrieves a value by key from the specified tree.
+    ///
+    /// Returns `None` if the key does not exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if deserialization fails or the database operation fails.
+    pub fn get<T: DeserializeOwned>(&self, tree_name: &str, key: &str) -> Result<Option<T>> {
+        let tree = self.db.open_tree(tree_name)?;
+        match tree.get(key.as_bytes())? {
+            Some(bytes) => {
+                let value = serde_json::from_slice(&bytes)?;
+                Ok(Some(value))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Deletes a value by key from the specified tree.
+    ///
+    /// Returns `true` if the key existed and was deleted, `false` otherwise.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database operation fails.
+    pub fn delete(&self, tree_name: &str, key: &str) -> Result<bool> {
+        let tree = self.db.open_tree(tree_name)?;
+        let existed = tree.remove(key.as_bytes())?.is_some();
+        tree.flush()?;
+        Ok(existed)
+    }
+
+    /// Lists all values in the specified tree.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if deserialization fails or the database operation fails.
+    pub fn list<T: DeserializeOwned>(&self, tree_name: &str) -> Result<Vec<T>> {
+        let tree = self.db.open_tree(tree_name)?;
+        tree.iter().try_fold(Vec::new(), |mut results, item| {
+            let (_, value) = item?;
+            let parsed: T = serde_json::from_slice(&value)?;
+            results.push(parsed);
+            Ok(results)
+        })
+    }
+
+    /// Lists all keys in the specified tree.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database operation fails.
+    pub fn keys(&self, tree_name: &str) -> Result<Vec<String>> {
+        let tree = self.db.open_tree(tree_name)?;
+        tree.iter().try_fold(Vec::new(), |mut keys, item| {
+            let (key, _) = item?;
+            if let Ok(key_str) = String::from_utf8(key.to_vec()) {
+                keys.push(key_str);
+            }
+            Ok(keys)
+        })
+    }
+
+    /// Counts the number of entries in the specified tree.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database operation fails.
+    pub fn count(&self, tree_name: &str) -> Result<usize> {
+        let tree = self.db.open_tree(tree_name)?;
+        Ok(tree.len())
+    }
+
+    /// Clears all entries in the specified tree.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database operation fails.
+    pub fn clear(&self, tree_name: &str) -> Result<()> {
+        let tree = self.db.open_tree(tree_name)?;
+        tree.clear()?;
+        tree.flush()?;
+        Ok(())
+    }
+
+    /// Flushes all pending writes to disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the flush operation fails.
+    pub fn flush(&self) -> Result<()> {
+        self.db.flush()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use tempfile::tempdir;
+
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    struct TestData {
+        id: String,
+        value: i32,
+    }
+
+    fn create_test_store() -> (StateStore, tempfile::TempDir) {
+        let dir = tempdir().expect("should create temp dir");
+        let db = sled::open(dir.path()).expect("should open db");
+        let store = StateStore::new(Arc::new(db));
+        (store, dir)
+    }
+
+    #[test]
+    fn test_put_and_get() {
+        let (store, _dir) = create_test_store();
+
+        let data = TestData {
+            id: "test-1".to_string(),
+            value: 42,
+        };
+
+        store.put("test_tree", "key1", &data).expect("should put");
+
+        let retrieved: Option<TestData> = store.get("test_tree", "key1").expect("should get");
+        assert_eq!(retrieved, Some(data));
+    }
+
+    #[test]
+    fn test_get_nonexistent() {
+        let (store, _dir) = create_test_store();
+
+        let retrieved: Option<TestData> = store.get("test_tree", "nonexistent").expect("should get");
+        assert_eq!(retrieved, None);
+    }
+
+    #[test]
+    fn test_delete() {
+        let (store, _dir) = create_test_store();
+
+        let data = TestData {
+            id: "test-1".to_string(),
+            value: 42,
+        };
+
+        store.put("test_tree", "key1", &data).expect("should put");
+
+        let deleted = store.delete("test_tree", "key1").expect("should delete");
+        assert!(deleted);
+
+        let retrieved: Option<TestData> = store.get("test_tree", "key1").expect("should get");
+        assert_eq!(retrieved, None);
+    }
+
+    #[test]
+    fn test_delete_nonexistent() {
+        let (store, _dir) = create_test_store();
+
+        let deleted = store.delete("test_tree", "nonexistent").expect("should delete");
+        assert!(!deleted);
+    }
+
+    #[test]
+    fn test_list() {
+        let (store, _dir) = create_test_store();
+
+        let data1 = TestData {
+            id: "test-1".to_string(),
+            value: 1,
+        };
+        let data2 = TestData {
+            id: "test-2".to_string(),
+            value: 2,
+        };
+
+        store.put("test_tree", "key1", &data1).expect("should put");
+        store.put("test_tree", "key2", &data2).expect("should put");
+
+        let items: Vec<TestData> = store.list("test_tree").expect("should list");
+        assert_eq!(items.len(), 2);
+        assert!(items.contains(&data1));
+        assert!(items.contains(&data2));
+    }
+
+    #[test]
+    fn test_keys() {
+        let (store, _dir) = create_test_store();
+
+        let data = TestData {
+            id: "test-1".to_string(),
+            value: 1,
+        };
+
+        store.put("test_tree", "key1", &data).expect("should put");
+        store.put("test_tree", "key2", &data).expect("should put");
+
+        let keys = store.keys("test_tree").expect("should get keys");
+        assert_eq!(keys.len(), 2);
+        assert!(keys.contains(&"key1".to_string()));
+        assert!(keys.contains(&"key2".to_string()));
+    }
+
+    #[test]
+    fn test_count() {
+        let (store, _dir) = create_test_store();
+
+        assert_eq!(store.count("test_tree").expect("should count"), 0);
+
+        let data = TestData {
+            id: "test-1".to_string(),
+            value: 1,
+        };
+
+        store.put("test_tree", "key1", &data).expect("should put");
+        assert_eq!(store.count("test_tree").expect("should count"), 1);
+
+        store.put("test_tree", "key2", &data).expect("should put");
+        assert_eq!(store.count("test_tree").expect("should count"), 2);
+    }
+
+    #[test]
+    fn test_clear() {
+        let (store, _dir) = create_test_store();
+
+        let data = TestData {
+            id: "test-1".to_string(),
+            value: 1,
+        };
+
+        store.put("test_tree", "key1", &data).expect("should put");
+        store.put("test_tree", "key2", &data).expect("should put");
+        assert_eq!(store.count("test_tree").expect("should count"), 2);
+
+        store.clear("test_tree").expect("should clear");
+        assert_eq!(store.count("test_tree").expect("should count"), 0);
+    }
+
+    #[test]
+    fn test_separate_trees() {
+        let (store, _dir) = create_test_store();
+
+        let data1 = TestData {
+            id: "test-1".to_string(),
+            value: 1,
+        };
+        let data2 = TestData {
+            id: "test-2".to_string(),
+            value: 2,
+        };
+
+        store.put("tree_a", "key1", &data1).expect("should put");
+        store.put("tree_b", "key1", &data2).expect("should put");
+
+        let from_a: Option<TestData> = store.get("tree_a", "key1").expect("should get");
+        let from_b: Option<TestData> = store.get("tree_b", "key1").expect("should get");
+
+        assert_eq!(from_a, Some(data1));
+        assert_eq!(from_b, Some(data2));
+    }
+}


### PR DESCRIPTION
## Summary

- Add basic daemon infrastructure with HTTP API server, state persistence, and event system
- Implement `fabricks daemon info` CLI command to query the running daemon
- All 64 tests pass, clippy clean

## Changes

### Daemon (fabricksd)
- **error.rs**: DaemonError enum with thiserror
- **config.rs**: DaemonConfig with nested settings structs (socket, data_dir, api, runtime, resources, monitoring, events)
- **state.rs**: AppState shared state container with sled database
- **shutdown.rs**: Graceful shutdown handling on SIGTERM/SIGINT
- **store/**: Sled-backed StateStore for key-value persistence
- **events/**: EventBus pub/sub system with filtering and ring buffer history
- **api/**: Axum router with `/v1/daemon/info` and `/v1/health` endpoints

### CLI (fabricks)
- **daemon_client.rs**: Unix socket HTTP client for daemon communication
- **commands/daemon.rs**: `fabricks daemon info` command with text/JSON output

## Test plan

- [x] Daemon starts successfully with `cargo run --bin fabricksd`
- [x] Unix socket created at configured path
- [x] `/v1/daemon/info` endpoint returns proper JSON response
- [x] State persists to sled database (verified via tests)
- [x] Event bus publishes and receives events (verified via tests)
- [x] Graceful shutdown on SIGTERM/SIGINT
- [x] CLI can query daemon: `fabricks daemon info`
- [x] All tests pass: `cargo test -p fabricksd -p fabricks`
- [x] Clippy clean: `cargo clippy -p fabricksd -p fabricks -- -D warnings`