### PR TITLE
Fix service operations by name and enhance service inspect (#27, #28)

### DIFF
--- a/fabricks/src/commands/service.rs
+++ b/fabricks/src/commands/service.rs
@@ -398,6 +398,12 @@ async fn inspect_service(client: &DaemonClient, id: &str, format: OutputFormat) 
                 ))?;
             }
 
+            if !detail.ports.is_empty() {
+                let ports_str: Vec<String> =
+                    detail.ports.iter().map(|p| p.to_string()).collect();
+                output::writeln(&format!("  Ports:      {}", ports_str.join(", ")))?;
+            }
+
             if let Some(ref project) = detail.config.mortar_project {
                 output::writeln(&format!("  Project:    {project}"))?;
             }

--- a/fabricks/src/commands/service.rs
+++ b/fabricks/src/commands/service.rs
@@ -391,27 +391,86 @@ async fn inspect_service(client: &DaemonClient, id: &str, format: OutputFormat) 
             output::writeln(&format!("  WASM:       {}", detail.config.wasm_path))?;
             output::writeln(&format!("  Digest:     {}", detail.config.wasm_digest))?;
 
-            if !detail.config.networks.is_empty() {
-                output::writeln(&format!(
-                    "  Networks:   {}",
-                    detail.config.networks.join(", ")
-                ))?;
-            }
-
+            // Show bound ports
             if !detail.ports.is_empty() {
                 let ports_str: Vec<String> =
                     detail.ports.iter().map(|p| p.to_string()).collect();
                 output::writeln(&format!("  Ports:      {}", ports_str.join(", ")))?;
             }
 
+            // Show attached networks (from network manager)
+            if !detail.networks.is_empty() {
+                let networks_str: Vec<String> = detail
+                    .networks
+                    .iter()
+                    .map(|n| {
+                        if n.internal {
+                            format!("{} (internal)", n.name)
+                        } else {
+                            n.name.clone()
+                        }
+                    })
+                    .collect();
+                output::writeln(&format!("  Networks:   {}", networks_str.join(", ")))?;
+            }
+
+            // Show mortar project
             if let Some(ref project) = detail.config.mortar_project {
                 output::writeln(&format!("  Project:    {project}"))?;
             }
 
+            // Show dependencies
+            if !detail.config.depends_on.is_empty() {
+                output::writeln(&format!(
+                    "  Depends On: {}",
+                    detail.config.depends_on.join(", ")
+                ))?;
+            }
+
+            // Show last error
             if let Some(ref error) = detail.last_error {
                 output::writeln(&format!("  Last Error: {error}"))?;
             }
 
+            // Show capabilities section
+            output::writeln("")?;
+            output::writeln("Capabilities:")?;
+            output_capabilities(&detail.config.capabilities)?;
+
+            // Show volumes section
+            if !detail.config.volumes.is_empty() {
+                output::writeln("")?;
+                output::writeln("Volumes:")?;
+                for vol in &detail.config.volumes {
+                    let mode = if vol.read_only { "ro" } else { "rw" };
+                    output::writeln(&format!(
+                        "  - {} -> {} ({})",
+                        vol.volume_name, vol.guest_path, mode
+                    ))?;
+                }
+            }
+
+            // Show health check section
+            if let Some(ref hc) = detail.config.health_check {
+                output::writeln("")?;
+                output::writeln("Health Check:")?;
+                if let Some(obj) = hc.as_object() {
+                    if let Some(endpoint) = obj.get("endpoint") {
+                        output::writeln(&format!("  Endpoint:   {}", endpoint))?;
+                    }
+                    if let Some(interval) = obj.get("interval") {
+                        output::writeln(&format!("  Interval:   {}", interval))?;
+                    }
+                    if let Some(timeout) = obj.get("timeout") {
+                        output::writeln(&format!("  Timeout:    {}", timeout))?;
+                    }
+                    if let Some(retries) = obj.get("retries") {
+                        output::writeln(&format!("  Retries:    {}", retries))?;
+                    }
+                }
+            }
+
+            // Show instances section
             if !detail.instances.is_empty() {
                 output::writeln("")?;
                 output::writeln("Instances:")?;
@@ -424,6 +483,101 @@ async fn inspect_service(client: &DaemonClient, id: &str, format: OutputFormat) 
                 }
             }
         }
+    }
+
+    Ok(())
+}
+
+/// Outputs capabilities in a human-readable format.
+fn output_capabilities(caps: &serde_json::Value) -> Result<()> {
+    let obj = match caps.as_object() {
+        Some(o) => o,
+        None => {
+            output::writeln("  (none)")?;
+            return Ok(());
+        }
+    };
+
+    let mut has_any = false;
+
+    // Environment variables
+    if let Some(env) = obj.get("env") {
+        if let Some(arr) = env.as_array() {
+            if !arr.is_empty() {
+                has_any = true;
+                let vars: Vec<String> = arr
+                    .iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect();
+                output::writeln(&format!("  Environment: {}", vars.join(", ")))?;
+            }
+        }
+    }
+
+    // Network capabilities
+    if let Some(network) = obj.get("network") {
+        if let Some(net_obj) = network.as_object() {
+            // Listen ports
+            if let Some(listen) = net_obj.get("listen") {
+                if let Some(arr) = listen.as_array() {
+                    if !arr.is_empty() {
+                        has_any = true;
+                        let ports: Vec<String> =
+                            arr.iter().filter_map(|v| v.as_u64().map(|p| p.to_string())).collect();
+                        output::writeln(&format!("  Listen:      {}", ports.join(", ")))?;
+                    }
+                }
+            }
+            // Connect hosts
+            if let Some(connect) = net_obj.get("connect") {
+                if let Some(arr) = connect.as_array() {
+                    if !arr.is_empty() {
+                        has_any = true;
+                        let hosts: Vec<String> = arr
+                            .iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect();
+                        output::writeln(&format!("  Connect:     {}", hosts.join(", ")))?;
+                    }
+                }
+            }
+        }
+    }
+
+    // Filesystem capabilities
+    if let Some(filesystem) = obj.get("filesystem") {
+        if let Some(fs_obj) = filesystem.as_object() {
+            // Read paths
+            if let Some(read) = fs_obj.get("read") {
+                if let Some(arr) = read.as_array() {
+                    if !arr.is_empty() {
+                        has_any = true;
+                        let paths: Vec<String> = arr
+                            .iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect();
+                        output::writeln(&format!("  FS Read:     {}", paths.join(", ")))?;
+                    }
+                }
+            }
+            // Write paths
+            if let Some(write) = fs_obj.get("write") {
+                if let Some(arr) = write.as_array() {
+                    if !arr.is_empty() {
+                        has_any = true;
+                        let paths: Vec<String> = arr
+                            .iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect();
+                        output::writeln(&format!("  FS Write:    {}", paths.join(", ")))?;
+                    }
+                }
+            }
+        }
+    }
+
+    if !has_any {
+        output::writeln("  (none)")?;
     }
 
     Ok(())

--- a/fabricks/src/daemon_client.rs
+++ b/fabricks/src/daemon_client.rs
@@ -144,6 +144,20 @@ pub struct ServiceDetail {
     /// Bound ports.
     #[serde(default)]
     pub ports: Vec<u16>,
+    /// Attached networks.
+    #[serde(default)]
+    pub networks: Vec<NetworkAttachment>,
+}
+
+/// Network attachment information.
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct NetworkAttachment {
+    /// Network ID.
+    pub id: String,
+    /// Network name.
+    pub name: String,
+    /// Whether this is an internal-only network.
+    pub internal: bool,
 }
 
 /// Service configuration details.
@@ -159,12 +173,36 @@ pub struct ServiceConfigDetail {
     pub wasm_path: String,
     /// WASM digest.
     pub wasm_digest: String,
-    /// Networks.
+    /// Capabilities granted to the service.
+    #[serde(default)]
+    pub capabilities: serde_json::Value,
+    /// Volume mounts.
+    #[serde(default)]
+    pub volumes: Vec<VolumeMountInfo>,
+    /// Health check configuration.
+    #[serde(default)]
+    pub health_check: Option<serde_json::Value>,
+    /// Service dependencies.
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+    /// Networks (from config).
     #[serde(default)]
     pub networks: Vec<String>,
     /// Mortar project.
     #[serde(default)]
     pub mortar_project: Option<String>,
+}
+
+/// Volume mount information.
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct VolumeMountInfo {
+    /// Volume name.
+    pub volume_name: String,
+    /// Guest mount path.
+    pub guest_path: String,
+    /// Whether read-only.
+    #[serde(default)]
+    pub read_only: bool,
 }
 
 /// Instance information.

--- a/fabricks/src/daemon_client.rs
+++ b/fabricks/src/daemon_client.rs
@@ -141,6 +141,9 @@ pub struct ServiceDetail {
     /// Running instances.
     #[serde(default)]
     pub instances: Vec<InstanceInfo>,
+    /// Bound ports.
+    #[serde(default)]
+    pub ports: Vec<u16>,
 }
 
 /// Service configuration details.

--- a/fabricksd/src/api/handlers/services.rs
+++ b/fabricksd/src/api/handlers/services.rs
@@ -236,19 +236,35 @@ pub async fn get_service(
     let manager = state.service_manager.read().await;
 
     match manager.get_service_by_id_or_name(&id_or_name).await {
-        Ok(detail) => Json(ApiResponse::success(detail)),
+        Ok(mut detail) => {
+            // Populate port bindings from proxy server
+            let bindings = state.proxy_server.list_bindings().await;
+            detail.ports = bindings
+                .into_iter()
+                .filter(|b| b.service_id == detail.id)
+                .map(|b| b.port)
+                .collect();
+
+            Json(ApiResponse::success(detail))
+        }
         Err(e) => Json(error_response(&e)),
     }
 }
 
 /// POST `/v1/services/:id/start`
 ///
-/// Starts a service.
+/// Starts a service. The path parameter can be either a service ID or name.
 pub async fn start_service(
     State(state): State<AppState>,
-    Path(id): Path<String>,
+    Path(id_or_name): Path<String>,
 ) -> Json<ApiResponse<()>> {
     let manager = state.service_manager.write().await;
+
+    // Resolve name to ID if needed
+    let id = match resolve_service_id(&manager, &id_or_name).await {
+        Ok(id) => id,
+        Err(e) => return Json(error_response(&e)),
+    };
 
     match manager.start_service(&id).await {
         Ok(()) => Json(ApiResponse::Success { data: () }),
@@ -258,12 +274,18 @@ pub async fn start_service(
 
 /// POST `/v1/services/:id/stop`
 ///
-/// Stops a service.
+/// Stops a service. The path parameter can be either a service ID or name.
 pub async fn stop_service(
     State(state): State<AppState>,
-    Path(id): Path<String>,
+    Path(id_or_name): Path<String>,
 ) -> Json<ApiResponse<()>> {
     let manager = state.service_manager.write().await;
+
+    // Resolve name to ID if needed
+    let id = match resolve_service_id(&manager, &id_or_name).await {
+        Ok(id) => id,
+        Err(e) => return Json(error_response(&e)),
+    };
 
     match manager.stop_service(&id).await {
         Ok(()) => Json(ApiResponse::Success { data: () }),
@@ -274,12 +296,19 @@ pub async fn stop_service(
 /// POST `/v1/services/:id/scale`
 ///
 /// Scales a service to a target number of replicas.
+/// The path parameter can be either a service ID or name.
 pub async fn scale_service(
     State(state): State<AppState>,
-    Path(id): Path<String>,
+    Path(id_or_name): Path<String>,
     Json(req): Json<ScaleServiceRequest>,
 ) -> Json<ApiResponse<()>> {
     let manager = state.service_manager.write().await;
+
+    // Resolve name to ID if needed
+    let id = match resolve_service_id(&manager, &id_or_name).await {
+        Ok(id) => id,
+        Err(e) => return Json(error_response(&e)),
+    };
 
     match manager.scale_service(&id, req.replicas).await {
         Ok(()) => Json(ApiResponse::Success { data: () }),
@@ -289,17 +318,38 @@ pub async fn scale_service(
 
 /// DELETE `/v1/services/:id`
 ///
-/// Deletes a service.
+/// Deletes a service. The path parameter can be either a service ID or name.
 pub async fn delete_service(
     State(state): State<AppState>,
-    Path(id): Path<String>,
+    Path(id_or_name): Path<String>,
 ) -> Json<ApiResponse<()>> {
     let manager = state.service_manager.write().await;
+
+    // Resolve name to ID if needed
+    let id = match resolve_service_id(&manager, &id_or_name).await {
+        Ok(id) => id,
+        Err(e) => return Json(error_response(&e)),
+    };
 
     match manager.delete_service(&id).await {
         Ok(()) => Json(ApiResponse::Success { data: () }),
         Err(e) => Json(error_response(&e)),
     }
+}
+
+/// Resolves a service ID or name to an ID.
+async fn resolve_service_id(
+    manager: &crate::service::ServiceManager,
+    id_or_name: &str,
+) -> Result<String, DaemonError> {
+    // If it looks like an ID (starts with "svc-"), use it directly
+    if id_or_name.starts_with("svc-") {
+        return Ok(id_or_name.to_string());
+    }
+
+    // Otherwise, look up by name
+    let detail = manager.get_service_by_id_or_name(id_or_name).await?;
+    Ok(detail.id)
 }
 
 /// Computes SHA256 digest of bytes.

--- a/fabricksd/src/api/handlers/services.rs
+++ b/fabricksd/src/api/handlers/services.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::api::response::ApiResponse;
 use crate::error::DaemonError;
-use crate::service::{ServiceConfig, ServiceDetail, ServiceInfo};
+use crate::service::{NetworkAttachment, ServiceConfig, ServiceDetail, ServiceInfo};
 use crate::state::AppState;
 use crate::volume::VolumeMount;
 use fabricks_common::Fabrickfile;
@@ -244,6 +244,18 @@ pub async fn get_service(
                 .filter(|b| b.service_id == detail.id)
                 .map(|b| b.port)
                 .collect();
+
+            // Populate network attachments from network manager
+            let network_ids = state.network_manager.get_service_networks(&detail.id).await;
+            for network_id in network_ids {
+                if let Some(network) = state.network_manager.get_network(&network_id).await {
+                    detail.networks.push(NetworkAttachment {
+                        id: network.id,
+                        name: network.name,
+                        internal: network.options.access.is_internal(),
+                    });
+                }
+            }
 
             Json(ApiResponse::success(detail))
         }

--- a/fabricksd/src/service/handle.rs
+++ b/fabricksd/src/service/handle.rs
@@ -179,6 +179,7 @@ impl ServiceHandle {
             last_error: state.last_error.clone(),
             instances,
             mortar_project: state.mortar_project.clone(),
+            ports: Vec::new(), // Populated by API handler from proxy server
         }
     }
 

--- a/fabricksd/src/service/handle.rs
+++ b/fabricksd/src/service/handle.rs
@@ -179,7 +179,8 @@ impl ServiceHandle {
             last_error: state.last_error.clone(),
             instances,
             mortar_project: state.mortar_project.clone(),
-            ports: Vec::new(), // Populated by API handler from proxy server
+            ports: Vec::new(),    // Populated by API handler from proxy server
+            networks: Vec::new(), // Populated by API handler from network manager
         }
     }
 

--- a/fabricksd/src/service/mod.rs
+++ b/fabricksd/src/service/mod.rs
@@ -52,6 +52,6 @@ pub mod types;
 pub use handle::{CapabilityOutboundHandler, ServiceHandle};
 pub use manager::ServiceManager;
 pub use types::{
-    Instance, InstanceState, ReplicaState, ServiceConfig, ServiceDetail, ServiceInfo, ServiceState,
-    State, generate_instance_id, generate_service_id,
+    Instance, InstanceState, NetworkAttachment, ReplicaState, ServiceConfig, ServiceDetail,
+    ServiceInfo, ServiceState, State, generate_instance_id, generate_service_id,
 };

--- a/fabricksd/src/service/types.rs
+++ b/fabricksd/src/service/types.rs
@@ -424,6 +424,23 @@ pub struct ServiceDetail {
     /// Bound ports (populated from proxy server).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub ports: Vec<u16>,
+
+    /// Attached networks (populated from network manager).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub networks: Vec<NetworkAttachment>,
+}
+
+/// Network attachment information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NetworkAttachment {
+    /// Network ID.
+    pub id: String,
+
+    /// Network name.
+    pub name: String,
+
+    /// Whether this is an internal-only network.
+    pub internal: bool,
 }
 
 /// Generates a unique service ID.

--- a/fabricksd/src/service/types.rs
+++ b/fabricksd/src/service/types.rs
@@ -420,6 +420,10 @@ pub struct ServiceDetail {
     /// Optional mortar project.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mortar_project: Option<String>,
+
+    /// Bound ports (populated from proxy server).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ports: Vec<u16>,
 }
 
 /// Generates a unique service ID.


### PR DESCRIPTION
## Summary
- Service operations (start/stop/scale/delete) now accept service names in addition to IDs by adding `resolve_service_id` helper
- Service inspect now displays comprehensive information:
  - Bound ports from proxy server
  - Attached networks with internal/external status
  - Capabilities (environment, network, filesystem)
  - Volume mounts with read-only indicator
  - Health check configuration
  - Dependencies

## Example Output
```
Service: api-gateway
  ID:         svc-abb2d704
  Version:    latest
  State:      running
  Type:       http
  Replicas:   1/1
  Created:    2026-01-25T19:15:11.075125Z
  Updated:    2026-01-25T19:15:11.268580Z
  WASM:       .../api_gateway.wasm
  Digest:     sha256:e6017803350ef7e3d275f269842250bc7529eb30544dd71160851fc16dac1d61
  Ports:      8085
  Networks:   dmz, application (internal)
  Project:    e-commerce

Capabilities:
  Listen:      8085

Volumes:
  - app-source -> /app (ro)
```

Fixes #27, Fixes #28

## Test plan
- [x] Verified service stop/start/scale/delete work by name
- [x] Verified service inspect shows ports
- [x] Verified service inspect shows attached networks with internal flag
- [x] Verified service inspect shows capabilities
- [x] Verified service inspect shows volume mounts
- [x] All tests pass